### PR TITLE
IDCOM-291 Export constants from gatekeeper-lib so that we can refer t…

### DIFF
--- a/solana/gatekeeper-lib/src/index.ts
+++ b/solana/gatekeeper-lib/src/index.ts
@@ -1,3 +1,3 @@
 export { run } from "@oclif/command";
 export * from "./service";
-export { getConnection, airdropTo, Recorder, AuditRecord } from "./util";
+export { getConnection, airdropTo, Recorder, AuditRecord, constants } from "./util";


### PR DESCRIPTION
Export constants from gatekeeper-lib so that we can refer to the PROGRAM_ID in tests.