### PR TITLE
IDCOM-514 - Expose findGatewayTokenForOwner in GatekeeperService

### DIFF
--- a/solana/gatekeeper-lib/src/service/GatekeeperService.ts
+++ b/solana/gatekeeper-lib/src/service/GatekeeperService.ts
@@ -9,6 +9,7 @@ import {
   revoke,
   unfreeze,
   updateExpiry,
+  findGatewayToken,
 } from "@identity.com/solana-gateway-ts";
 import { AuditRecord, PII, Recorder, RecorderFS } from "../util/record";
 import { send } from "../util/connection";
@@ -217,6 +218,12 @@ export class GatekeeperService {
     );
 
     return gatewayToken;
+  }
+
+  async findGatewayTokenForOwner(
+    owner: PublicKey
+  ): Promise<GatewayToken | null> {
+    return findGatewayToken(this.connection, owner, this.gatekeeperNetwork);
   }
 
   async updateExpiry(


### PR DESCRIPTION
Expose _findGatewayTokenForOwner_ in the _GatekeeperService_ to retrieve/find the token given the owner/wallet address.