### PR TITLE
IDCOM-514 - Update client to use wallet address for refresh

### DIFF
--- a/solana/gateway-http-client/src/lib/gatewayHttpClient.ts
+++ b/solana/gateway-http-client/src/lib/gatewayHttpClient.ts
@@ -113,7 +113,7 @@ export class GatekeeperClient implements GatekeeperClientInterface {
       await this.callGatekeeper<RefreshTokenRequestBody, GatekeeperResponse>(
         "PATCH",
         { proof },
-        `/${request.token.toBase58()}/refresh`
+        `/${request.wallet.toBase58()}/refresh`
       );
     } catch (error) {
       if (error.response)

--- a/solana/gateway-http-client/test/unit/GatekeeperClient.test.ts
+++ b/solana/gateway-http-client/test/unit/GatekeeperClient.test.ts
@@ -280,9 +280,10 @@ describe("GatekeeperClient", () => {
     let gatekeeperClientInst: GatekeeperClient;
     const baseUrl = "test_baseUrl";
     const token = Keypair.generate().publicKey;
-    const refreshUrl = `${baseUrl}/${token.toBase58()}/refresh`;
+    let refreshUrl: string;
 
     beforeEach(() => {
+      refreshUrl = `${baseUrl}/${walletPublicKey.toBase58()}/refresh`;
       gatekeeperClientInst = new GatekeeperClient({ baseUrl });
     });
 


### PR DESCRIPTION
The gatekeeper API is now using the wallet address as primary key. So the http client has been updated to pass the wallet address for the refresh endpoint instead of the token. 