### PR TITLE
CLI Updates

### DIFF
--- a/solana/gatekeeper-lib/README.md
+++ b/solana/gatekeeper-lib/README.md
@@ -19,7 +19,7 @@ $ npm install -g @identity.com/solana-gatekeeper-lib
 $ gateway COMMAND
 running command...
 $ gateway (-v|--version|version)
-@identity.com/solana-gatekeeper-lib/1.1.0 darwin-x64 node-v16.4.1
+@identity.com/solana-gatekeeper-lib/1.1.0 darwin-x64 node-v16.0.0
 $ gateway --help [COMMAND]
 USAGE
   $ gateway COMMAND
@@ -88,8 +88,8 @@ OPTIONS
 
   -h, --help                                       show CLI help
 
-  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The private key file for the gatekeeper
-                                                   authority
+  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The public key (in base 58) of the
+                                                   gatekeeper network that the gatekeeper belongs to.
 
 EXAMPLE
   $ gateway freeze EzZgkwaDrgycsiyGeCVRXXRcieE1fxhGMp829qwj5TMv
@@ -138,8 +138,8 @@ OPTIONS
 
   -h, --help                                       show CLI help
 
-  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The private key file for the gatekeeper
-                                                   authority
+  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The public key (in base 58) of the
+                                                   gatekeeper network that the gatekeeper belongs to.
 
 EXAMPLE
   $ gateway issue EzZgkwaDrgycsiyGeCVRXXRcieE1fxhGMp829qwj5TMv2QJjjrzdPSrcZUuAH2KrEU61crWz49KnSLSzwjDUnLSV
@@ -169,8 +169,8 @@ OPTIONS
 
   -h, --help                                       show CLI help
 
-  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The private key file for the gatekeeper
-                                                   authority
+  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The public key (in base 58) of the
+                                                   gatekeeper network that the gatekeeper belongs to.
 
 EXAMPLE
   $ gateway refresh EzZgkwaDrgycsiyGeCVRXXRcieE1fxhGMp829qwj5TMv 54000
@@ -200,8 +200,8 @@ OPTIONS
 
   -h, --help                                       show CLI help
 
-  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The private key file for the gatekeeper
-                                                   authority
+  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The public key (in base 58) of the
+                                                   gatekeeper network that the gatekeeper belongs to.
 
 EXAMPLE
   $ gateway revoke EzZgkwaDrgycsiyGeCVRXXRcieE1fxhGMp829qwj5TMv
@@ -231,8 +231,8 @@ OPTIONS
 
   -h, --help                                       show CLI help
 
-  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The private key file for the gatekeeper
-                                                   authority
+  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The public key (in base 58) of the
+                                                   gatekeeper network that the gatekeeper belongs to.
 
 EXAMPLE
   $ gateway unfreeze EzZgkwaDrgycsiyGeCVRXXRcieE1fxhGMp829qwj5TMv
@@ -259,8 +259,8 @@ OPTIONS
 
   -h, --help                                       show CLI help
 
-  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The private key file for the gatekeeper
-                                                   authority
+  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The public key (in base 58) of the
+                                                   gatekeeper network that the gatekeeper belongs to.
 
 EXAMPLE
   $ gateway verify EzZgkwaDrgycsiyGeCVRXXRcieE1fxhGMp829qwj5TMv

--- a/solana/gatekeeper-lib/docs/classes/GatekeeperNetworkService.html
+++ b/solana/gatekeeper-lib/docs/classes/GatekeeperNetworkService.html
@@ -112,7 +112,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/e8d73a8/solana/gatekeeper-lib/src/service/GatekeeperNetworkService.ts#L18">service/GatekeeperNetworkService.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/dba4fc0/solana/gatekeeper-lib/src/service/GatekeeperNetworkService.ts#L18">service/GatekeeperNetworkService.ts:18</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -164,7 +164,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/e8d73a8/solana/gatekeeper-lib/src/service/GatekeeperNetworkService.ts#L28">service/GatekeeperNetworkService.ts:28</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/dba4fc0/solana/gatekeeper-lib/src/service/GatekeeperNetworkService.ts#L28">service/GatekeeperNetworkService.ts:28</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -194,7 +194,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/e8d73a8/solana/gatekeeper-lib/src/service/GatekeeperNetworkService.ts#L57">service/GatekeeperNetworkService.ts:57</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/dba4fc0/solana/gatekeeper-lib/src/service/GatekeeperNetworkService.ts#L57">service/GatekeeperNetworkService.ts:57</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/solana/gatekeeper-lib/docs/classes/GatekeeperService.html
+++ b/solana/gatekeeper-lib/docs/classes/GatekeeperService.html
@@ -116,7 +116,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/e8d73a8/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L35">service/GatekeeperService.ts:35</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/dba4fc0/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L35">service/GatekeeperService.ts:35</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -184,7 +184,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/e8d73a8/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L196">service/GatekeeperService.ts:196</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/dba4fc0/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L196">service/GatekeeperService.ts:196</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -214,7 +214,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/e8d73a8/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L140">service/GatekeeperService.ts:140</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/dba4fc0/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L140">service/GatekeeperService.ts:140</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -244,7 +244,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/e8d73a8/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L105">service/GatekeeperService.ts:105</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/dba4fc0/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L105">service/GatekeeperService.ts:105</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -274,7 +274,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/e8d73a8/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L113">service/GatekeeperService.ts:113</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/dba4fc0/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L113">service/GatekeeperService.ts:113</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -304,7 +304,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/e8d73a8/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L168">service/GatekeeperService.ts:168</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/dba4fc0/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L168">service/GatekeeperService.ts:168</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -334,7 +334,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/e8d73a8/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L207">service/GatekeeperService.ts:207</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/dba4fc0/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L207">service/GatekeeperService.ts:207</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/solana/gatekeeper-lib/src/commands/freeze.ts
+++ b/solana/gatekeeper-lib/src/commands/freeze.ts
@@ -3,7 +3,7 @@ import { PublicKey } from "@solana/web3.js";
 import {
   clusterFlag,
   gatekeeperKeyFlag,
-  gatekeeperNetworkKeyFlag,
+  gatekeeperNetworkPubkeyFlag,
 } from "../util/oclif/flags";
 import { getTokenUpdateProperties } from "../util/oclif/utils";
 
@@ -19,7 +19,7 @@ Frozen
   static flags = {
     help: flags.help({ char: "h" }),
     gatekeeperKey: gatekeeperKeyFlag(),
-    gatekeeperNetworkKey: gatekeeperNetworkKeyFlag(),
+    gatekeeperNetworkKey: gatekeeperNetworkPubkeyFlag(),
     cluster: clusterFlag(),
   };
 

--- a/solana/gatekeeper-lib/src/commands/refresh.ts
+++ b/solana/gatekeeper-lib/src/commands/refresh.ts
@@ -3,7 +3,7 @@ import { PublicKey } from "@solana/web3.js";
 import {
   clusterFlag,
   gatekeeperKeyFlag,
-  gatekeeperNetworkKeyFlag,
+  gatekeeperNetworkPubkeyFlag,
 } from "../util/oclif/flags";
 import { getTokenUpdateProperties } from "../util/oclif/utils";
 
@@ -19,7 +19,7 @@ Refreshed
   static flags = {
     help: flags.help({ char: "h" }),
     gatekeeperKey: gatekeeperKeyFlag(),
-    gatekeeperNetworkKey: gatekeeperNetworkKeyFlag(),
+    gatekeeperNetworkKey: gatekeeperNetworkPubkeyFlag(),
     cluster: clusterFlag(),
   };
 

--- a/solana/gatekeeper-lib/src/commands/revoke.ts
+++ b/solana/gatekeeper-lib/src/commands/revoke.ts
@@ -3,7 +3,7 @@ import { PublicKey } from "@solana/web3.js";
 import {
   clusterFlag,
   gatekeeperKeyFlag,
-  gatekeeperNetworkKeyFlag,
+  gatekeeperNetworkPubkeyFlag,
 } from "../util/oclif/flags";
 import { getTokenUpdateProperties } from "../util/oclif/utils";
 
@@ -19,7 +19,7 @@ Revoked
   static flags = {
     help: flags.help({ char: "h" }),
     gatekeeperKey: gatekeeperKeyFlag(),
-    gatekeeperNetworkKey: gatekeeperNetworkKeyFlag(),
+    gatekeeperNetworkKey: gatekeeperNetworkPubkeyFlag(),
     cluster: clusterFlag(),
   };
 

--- a/solana/gatekeeper-lib/src/commands/unfreeze.ts
+++ b/solana/gatekeeper-lib/src/commands/unfreeze.ts
@@ -3,7 +3,7 @@ import { PublicKey } from "@solana/web3.js";
 import {
   clusterFlag,
   gatekeeperKeyFlag,
-  gatekeeperNetworkKeyFlag,
+  gatekeeperNetworkPubkeyFlag,
 } from "../util/oclif/flags";
 import { getTokenUpdateProperties } from "../util/oclif/utils";
 
@@ -19,7 +19,7 @@ Unfrozen
   static flags = {
     help: flags.help({ char: "h" }),
     gatekeeperKey: gatekeeperKeyFlag(),
-    gatekeeperNetworkKey: gatekeeperNetworkKeyFlag(),
+    gatekeeperNetworkKey: gatekeeperNetworkPubkeyFlag(),
     cluster: clusterFlag(),
   };
 

--- a/solana/gatekeeper-lib/src/commands/verify.ts
+++ b/solana/gatekeeper-lib/src/commands/verify.ts
@@ -1,17 +1,12 @@
-import {
-  findGatewayToken,
-  findGatewayTokens,
-} from "@identity.com/solana-gateway-ts";
+import { findGatewayTokens } from "@identity.com/solana-gateway-ts";
 import { Command, flags } from "@oclif/command";
 import { Keypair, PublicKey } from "@solana/web3.js";
-import { getConnection } from "../util/connection";
+import { getConnection } from "../util";
 import {
   clusterFlag,
-  gatekeeperKeyFlag,
   gatekeeperNetworkKeyFlag,
+  gatekeeperNetworkPubkeyFlag,
 } from "../util/oclif/flags";
-import { airdropTo } from "../util";
-import { GatekeeperService } from "../service";
 import { prettyPrint } from "../util/token";
 
 export default class Verify extends Command {
@@ -32,7 +27,7 @@ export default class Verify extends Command {
 
   static flags = {
     help: flags.help({ char: "h" }),
-    gatekeeperNetworkKey: gatekeeperNetworkKeyFlag(),
+    gatekeeperNetworkKey: gatekeeperNetworkPubkeyFlag(),
     cluster: clusterFlag(),
   };
 
@@ -48,18 +43,17 @@ export default class Verify extends Command {
   async run() {
     const { args, flags } = this.parse(Verify);
 
-    const gatewayToken: PublicKey = args.gatewayToken;
-    const gatekeeperNetwork = flags.gatekeeperNetworkKey as Keypair;
+    const gatekeeperNetwork = flags.gatekeeperNetworkKey as PublicKey;
 
     const connection = getConnection(flags.cluster);
 
     this.log(
-      `Verifying wallet ${args.owner.toBase58()} has a gateway token in the network ${gatekeeperNetwork.publicKey.toBase58()}`
+      `Verifying wallet ${args.owner.toBase58()} has a gateway token in the network ${gatekeeperNetwork.toBase58()}`
     );
     const tokens = await findGatewayTokens(
       connection,
       args.owner,
-      gatekeeperNetwork.publicKey,
+      gatekeeperNetwork,
       true
     );
 

--- a/solana/gatekeeper-lib/src/service/GatekeeperService.ts
+++ b/solana/gatekeeper-lib/src/service/GatekeeperService.ts
@@ -50,7 +50,7 @@ export class GatekeeperService {
     gatewayTokenKey: PublicKey
   ): Promise<GatewayToken> {
     return getGatewayToken(this.connection, gatewayTokenKey).then(
-      (gatewayToken) => {
+      (gatewayToken: GatewayToken | null) => {
         if (!gatewayToken)
           throw new Error(
             "Error retrieving gateway token at address " + gatewayTokenKey
@@ -229,5 +229,18 @@ export class GatekeeperService {
     );
 
     return this.getGatewayTokenOrError(gatewayTokenKey);
+  }
+
+  // equivalent to GatekeeperNetworkService.hasGatekeeper, but requires no network private key
+  async isRegistered(): Promise<boolean> {
+    const gatekeeperAccount = await getGatekeeperAccountKey(
+      this.gatekeeperAuthority.publicKey,
+      this.gatekeeperNetwork
+    );
+    const gatekeeperAccountInfo = await this.connection.getAccountInfo(
+      gatekeeperAccount
+    );
+
+    return !!gatekeeperAccountInfo;
   }
 }

--- a/solana/gatekeeper-lib/src/util/oclif/flags.ts
+++ b/solana/gatekeeper-lib/src/util/oclif/flags.ts
@@ -1,4 +1,4 @@
-import { Keypair } from "@solana/web3.js";
+import { Keypair, PublicKey } from "@solana/web3.js";
 import { flags } from "@oclif/command";
 import { readKey } from "../account";
 import { getClusterUrl } from "../connection";
@@ -14,6 +14,13 @@ export const gatekeeperNetworkKeyFlag = flags.build<Keypair>({
   parse: readKey,
   default: () => readKey(`${__dirname}/test-gatekeeper-network.json`),
   description: "The private key file for the gatekeeper authority",
+});
+export const gatekeeperNetworkPubkeyFlag = flags.build<PublicKey>({
+  char: "n",
+  parse: (pubkey: string) => new PublicKey(pubkey),
+  default: () => readKey(`${__dirname}/test-gatekeeper-network.json`).publicKey,
+  description:
+    "The public key (in base 58) of the gatekeeper network that the gatekeeper belongs to.",
 });
 export const clusterFlag = flags.build<string>({
   char: "c",

--- a/solana/gatekeeper-lib/src/util/oclif/utils.ts
+++ b/solana/gatekeeper-lib/src/util/oclif/utils.ts
@@ -6,7 +6,7 @@ import { GatekeeperService } from "../../service";
 export const getTokenUpdateProperties = async (
   args: { [p: string]: any },
   flags: {
-    gatekeeperNetworkKey: Keypair | undefined;
+    gatekeeperNetworkKey: PublicKey | undefined;
     help: void;
     cluster: string | undefined;
     gatekeeperKey: Keypair | undefined;
@@ -14,18 +14,14 @@ export const getTokenUpdateProperties = async (
 ) => {
   const gatewayToken: PublicKey = args.gatewayToken;
   const gatekeeper = flags.gatekeeperKey as Keypair;
-  const gatekeeperNetwork = flags.gatekeeperNetworkKey as Keypair;
+  const gatekeeperNetwork = flags.gatekeeperNetworkKey as PublicKey;
 
   const connection = getConnection(flags.cluster);
-  await airdropTo(
-    connection,
-    gatekeeperNetwork.publicKey,
-    flags.cluster as string
-  );
+  await airdropTo(connection, gatekeeper.publicKey, flags.cluster as string);
   const service = new GatekeeperService(
     connection,
+    gatekeeper,
     gatekeeperNetwork,
-    gatekeeperNetwork.publicKey,
     gatekeeper
   );
   return { gatewayToken, gatekeeper, service };

--- a/solana/gateway-ts/docs/classes/GatewayToken.html
+++ b/solana/gateway-ts/docs/classes/GatewayToken.html
@@ -117,7 +117,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/e8d73a8/solana/gateway-ts/src/types/index.ts#L9">types/index.ts:9</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/dba4fc0/solana/gateway-ts/src/types/index.ts#L9">types/index.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -213,7 +213,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/e8d73a8/solana/gateway-ts/src/types/index.ts#L24">types/index.ts:24</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/dba4fc0/solana/gateway-ts/src/types/index.ts#L24">types/index.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -230,7 +230,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/e8d73a8/solana/gateway-ts/src/types/index.ts#L20">types/index.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/dba4fc0/solana/gateway-ts/src/types/index.ts#L20">types/index.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>

--- a/solana/gateway-ts/docs/enums/State.html
+++ b/solana/gateway-ts/docs/enums/State.html
@@ -88,7 +88,7 @@
 					<div class="tsd-signature tsd-kind-icon">ACTIVE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;ACTIVE&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/e8d73a8/solana/gateway-ts/src/types/index.ts#L4">types/index.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/dba4fc0/solana/gateway-ts/src/types/index.ts#L4">types/index.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -98,7 +98,7 @@
 					<div class="tsd-signature tsd-kind-icon">FROZEN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;FROZEN&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/e8d73a8/solana/gateway-ts/src/types/index.ts#L6">types/index.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/dba4fc0/solana/gateway-ts/src/types/index.ts#L6">types/index.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -108,7 +108,7 @@
 					<div class="tsd-signature tsd-kind-icon">REVOKED<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;REVOKED&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/e8d73a8/solana/gateway-ts/src/types/index.ts#L5">types/index.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/dba4fc0/solana/gateway-ts/src/types/index.ts#L5">types/index.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/solana/gateway-ts/docs/index.html
+++ b/solana/gateway-ts/docs/index.html
@@ -108,7 +108,7 @@
 					<div class="tsd-signature tsd-kind-icon">Program<wbr>Account<wbr>Response<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>account<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">AccountInfo</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Buffer</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">; </span>pubkey<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">PublicKey</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/e8d73a8/solana/gateway-ts/src/types/index.ts#L30">types/index.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/dba4fc0/solana/gateway-ts/src/types/index.ts#L30">types/index.ts:30</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -136,7 +136,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/e8d73a8/solana/gateway-ts/src/lib/instruction.ts#L92">lib/instruction.ts:92</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/dba4fc0/solana/gateway-ts/src/lib/instruction.ts#L92">lib/instruction.ts:92</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -186,7 +186,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/e8d73a8/solana/gateway-ts/src/lib/util.ts#L151">lib/util.ts:151</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/dba4fc0/solana/gateway-ts/src/lib/util.ts#L151">lib/util.ts:151</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -230,7 +230,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/e8d73a8/solana/gateway-ts/src/lib/util.ts#L106">lib/util.ts:106</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/dba4fc0/solana/gateway-ts/src/lib/util.ts#L106">lib/util.ts:106</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -280,7 +280,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/e8d73a8/solana/gateway-ts/src/lib/instruction.ts#L197">lib/instruction.ts:197</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/dba4fc0/solana/gateway-ts/src/lib/instruction.ts#L197">lib/instruction.ts:197</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -324,7 +324,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/e8d73a8/solana/gateway-ts/src/lib/util.ts#L228">lib/util.ts:228</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/dba4fc0/solana/gateway-ts/src/lib/util.ts#L228">lib/util.ts:228</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -367,7 +367,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/e8d73a8/solana/gateway-ts/src/lib/util.ts#L21">lib/util.ts:21</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/dba4fc0/solana/gateway-ts/src/lib/util.ts#L21">lib/util.ts:21</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -404,7 +404,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/e8d73a8/solana/gateway-ts/src/lib/util.ts#L205">lib/util.ts:205</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/dba4fc0/solana/gateway-ts/src/lib/util.ts#L205">lib/util.ts:205</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -441,7 +441,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/e8d73a8/solana/gateway-ts/src/lib/util.ts#L42">lib/util.ts:42</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/dba4fc0/solana/gateway-ts/src/lib/util.ts#L42">lib/util.ts:42</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -484,7 +484,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/e8d73a8/solana/gateway-ts/src/lib/instruction.ts#L127">lib/instruction.ts:127</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/dba4fc0/solana/gateway-ts/src/lib/instruction.ts#L127">lib/instruction.ts:127</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -559,7 +559,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/e8d73a8/solana/gateway-ts/src/lib/util.ts#L184">lib/util.ts:184</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/dba4fc0/solana/gateway-ts/src/lib/util.ts#L184">lib/util.ts:184</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -626,7 +626,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/e8d73a8/solana/gateway-ts/src/lib/instruction.ts#L172">lib/instruction.ts:172</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/dba4fc0/solana/gateway-ts/src/lib/instruction.ts#L172">lib/instruction.ts:172</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -670,7 +670,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/e8d73a8/solana/gateway-ts/src/lib/instruction.ts#L222">lib/instruction.ts:222</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/dba4fc0/solana/gateway-ts/src/lib/instruction.ts#L222">lib/instruction.ts:222</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -714,7 +714,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/e8d73a8/solana/gateway-ts/src/lib/instruction.ts#L248">lib/instruction.ts:248</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/dba4fc0/solana/gateway-ts/src/lib/instruction.ts#L248">lib/instruction.ts:248</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">


### PR DESCRIPTION
Updated the solana gatekeeper lib CLI so that it no longer needs the gatekeeper network private key in order to perform gatekeeper actions.

Note - if a gatekeeper does not yet exist, this no longer automatically adds it to the network when it performs an action. This avoids accidentally using the wrong key and unintentionally creating a gatekeeper.