### PR TITLE
IDCOM-1369 Solana gatekeeper: tx config

### DIFF
--- a/.github/workflows/solana-rust.yml
+++ b/.github/workflows/solana-rust.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       matrix:
         rust: ['1.50']
-        solana: ['v1.7.3']
+        solana: ['stable']
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/solana-ts.yml
+++ b/.github/workflows/solana-ts.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         rust: [ '1.50' ]
-        solana: [ 'v1.7.3' ]
+        solana: [ 'stable' ]
         node: ['15.x']
         os: [ubuntu-latest]
 

--- a/solana/gatekeeper-lib/README.md
+++ b/solana/gatekeeper-lib/README.md
@@ -19,7 +19,7 @@ $ npm install -g @identity.com/solana-gatekeeper-lib
 $ gateway COMMAND
 running command...
 $ gateway (-v|--version|version)
-@identity.com/solana-gatekeeper-lib/1.1.2 darwin-x64 node-v16.0.0
+@identity.com/solana-gatekeeper-lib/1.1.3 darwin-x64 node-v16.0.0
 $ gateway --help [COMMAND]
 USAGE
   $ gateway COMMAND
@@ -66,7 +66,7 @@ EXAMPLE
   $ gateway add-gatekeeper tgky5YfBseCvqehzsycwCG6rh2udA4w14MxZMnZz9Hp
 ```
 
-_See code: [dist/commands/add-gatekeeper.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.1.2/dist/commands/add-gatekeeper.ts)_
+_See code: [dist/commands/add-gatekeeper.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.1.3/dist/commands/add-gatekeeper.ts)_
 
 ## `gateway freeze GATEWAYTOKEN`
 
@@ -98,7 +98,7 @@ EXAMPLE
   Frozen
 ```
 
-_See code: [dist/commands/freeze.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.1.2/dist/commands/freeze.ts)_
+_See code: [dist/commands/freeze.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.1.3/dist/commands/freeze.ts)_
 
 ## `gateway help [COMMAND]`
 
@@ -148,7 +148,7 @@ EXAMPLE
   $ gateway issue EzZgkwaDrgycsiyGeCVRXXRcieE1fxhGMp829qwj5TMv2QJjjrzdPSrcZUuAH2KrEU61crWz49KnSLSzwjDUnLSV
 ```
 
-_See code: [dist/commands/issue.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.1.2/dist/commands/issue.ts)_
+_See code: [dist/commands/issue.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.1.3/dist/commands/issue.ts)_
 
 ## `gateway refresh GATEWAYTOKEN [EXPIRY]`
 
@@ -181,7 +181,7 @@ EXAMPLE
   Refreshed
 ```
 
-_See code: [dist/commands/refresh.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.1.2/dist/commands/refresh.ts)_
+_See code: [dist/commands/refresh.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.1.3/dist/commands/refresh.ts)_
 
 ## `gateway revoke GATEWAYTOKEN`
 
@@ -213,7 +213,7 @@ EXAMPLE
   Revoked
 ```
 
-_See code: [dist/commands/revoke.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.1.2/dist/commands/revoke.ts)_
+_See code: [dist/commands/revoke.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.1.3/dist/commands/revoke.ts)_
 
 ## `gateway revoke-gatekeeper ADDRESS`
 
@@ -243,7 +243,7 @@ EXAMPLE
   $ gateway revoke-gatekeeper tgky5YfBseCvqehzsycwCG6rh2udA4w14MxZMnZz9Hp
 ```
 
-_See code: [dist/commands/revoke-gatekeeper.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.1.2/dist/commands/revoke-gatekeeper.ts)_
+_See code: [dist/commands/revoke-gatekeeper.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.1.3/dist/commands/revoke-gatekeeper.ts)_
 
 ## `gateway unfreeze GATEWAYTOKEN`
 
@@ -275,7 +275,7 @@ EXAMPLE
   Unfrozen
 ```
 
-_See code: [dist/commands/unfreeze.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.1.2/dist/commands/unfreeze.ts)_
+_See code: [dist/commands/unfreeze.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.1.3/dist/commands/unfreeze.ts)_
 
 ## `gateway verify OWNER`
 
@@ -311,5 +311,5 @@ EXAMPLE
   }
 ```
 
-_See code: [dist/commands/verify.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.1.2/dist/commands/verify.ts)_
+_See code: [dist/commands/verify.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.1.3/dist/commands/verify.ts)_
 <!-- commandsstop -->

--- a/solana/gatekeeper-lib/README.md
+++ b/solana/gatekeeper-lib/README.md
@@ -89,9 +89,8 @@ OPTIONS
 
   -h, --help                                       show CLI help
 
-  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: tgnuXXNMDLK8dy7Xm1TdeGyc95MDym4bvAQCwcW21Bf] The public key
-                                                   (in base 58) of the gatekeeper network that the gatekeeper belongs
-                                                   to.
+  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The public key (in base 58) of the
+                                                   gatekeeper network that the gatekeeper belongs to.
 
 EXAMPLE
   $ gateway freeze EzZgkwaDrgycsiyGeCVRXXRcieE1fxhGMp829qwj5TMv
@@ -140,9 +139,8 @@ OPTIONS
 
   -h, --help                                       show CLI help
 
-  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: tgnuXXNMDLK8dy7Xm1TdeGyc95MDym4bvAQCwcW21Bf] The public key
-                                                   (in base 58) of the gatekeeper network that the gatekeeper belongs
-                                                   to.
+  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The public key (in base 58) of the
+                                                   gatekeeper network that the gatekeeper belongs to.
 
 EXAMPLE
   $ gateway issue EzZgkwaDrgycsiyGeCVRXXRcieE1fxhGMp829qwj5TMv2QJjjrzdPSrcZUuAH2KrEU61crWz49KnSLSzwjDUnLSV
@@ -172,9 +170,8 @@ OPTIONS
 
   -h, --help                                       show CLI help
 
-  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: tgnuXXNMDLK8dy7Xm1TdeGyc95MDym4bvAQCwcW21Bf] The public key
-                                                   (in base 58) of the gatekeeper network that the gatekeeper belongs
-                                                   to.
+  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The public key (in base 58) of the
+                                                   gatekeeper network that the gatekeeper belongs to.
 
 EXAMPLE
   $ gateway refresh EzZgkwaDrgycsiyGeCVRXXRcieE1fxhGMp829qwj5TMv 54000
@@ -204,9 +201,8 @@ OPTIONS
 
   -h, --help                                       show CLI help
 
-  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: tgnuXXNMDLK8dy7Xm1TdeGyc95MDym4bvAQCwcW21Bf] The public key
-                                                   (in base 58) of the gatekeeper network that the gatekeeper belongs
-                                                   to.
+  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The public key (in base 58) of the
+                                                   gatekeeper network that the gatekeeper belongs to.
 
 EXAMPLE
   $ gateway revoke EzZgkwaDrgycsiyGeCVRXXRcieE1fxhGMp829qwj5TMv
@@ -266,9 +262,8 @@ OPTIONS
 
   -h, --help                                       show CLI help
 
-  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: tgnuXXNMDLK8dy7Xm1TdeGyc95MDym4bvAQCwcW21Bf] The public key
-                                                   (in base 58) of the gatekeeper network that the gatekeeper belongs
-                                                   to.
+  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The public key (in base 58) of the
+                                                   gatekeeper network that the gatekeeper belongs to.
 
 EXAMPLE
   $ gateway unfreeze EzZgkwaDrgycsiyGeCVRXXRcieE1fxhGMp829qwj5TMv
@@ -295,9 +290,8 @@ OPTIONS
 
   -h, --help                                       show CLI help
 
-  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: tgnuXXNMDLK8dy7Xm1TdeGyc95MDym4bvAQCwcW21Bf] The public key
-                                                   (in base 58) of the gatekeeper network that the gatekeeper belongs
-                                                   to.
+  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The public key (in base 58) of the
+                                                   gatekeeper network that the gatekeeper belongs to.
 
 EXAMPLE
   $ gateway verify EzZgkwaDrgycsiyGeCVRXXRcieE1fxhGMp829qwj5TMv

--- a/solana/gatekeeper-lib/README.md
+++ b/solana/gatekeeper-lib/README.md
@@ -19,7 +19,7 @@ $ npm install -g @identity.com/solana-gatekeeper-lib
 $ gateway COMMAND
 running command...
 $ gateway (-v|--version|version)
-@identity.com/solana-gatekeeper-lib/1.1.0 darwin-x64 node-v16.0.0
+@identity.com/solana-gatekeeper-lib/1.1.2 darwin-x64 node-v16.0.0
 $ gateway --help [COMMAND]
 USAGE
   $ gateway COMMAND
@@ -66,7 +66,7 @@ EXAMPLE
   $ gateway add-gatekeeper tgky5YfBseCvqehzsycwCG6rh2udA4w14MxZMnZz9Hp
 ```
 
-_See code: [dist/commands/add-gatekeeper.ts](https://github.com/identity-com/gatekeeper-lib/blob/v1.1.0/dist/commands/add-gatekeeper.ts)_
+_See code: [dist/commands/add-gatekeeper.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.1.2/dist/commands/add-gatekeeper.ts)_
 
 ## `gateway freeze GATEWAYTOKEN`
 
@@ -89,15 +89,16 @@ OPTIONS
 
   -h, --help                                       show CLI help
 
-  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The public key (in base 58) of the
-                                                   gatekeeper network that the gatekeeper belongs to.
+  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: tgnuXXNMDLK8dy7Xm1TdeGyc95MDym4bvAQCwcW21Bf] The public key
+                                                   (in base 58) of the gatekeeper network that the gatekeeper belongs
+                                                   to.
 
 EXAMPLE
   $ gateway freeze EzZgkwaDrgycsiyGeCVRXXRcieE1fxhGMp829qwj5TMv
   Frozen
 ```
 
-_See code: [dist/commands/freeze.ts](https://github.com/identity-com/gatekeeper-lib/blob/v1.1.0/dist/commands/freeze.ts)_
+_See code: [dist/commands/freeze.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.1.2/dist/commands/freeze.ts)_
 
 ## `gateway help [COMMAND]`
 
@@ -139,14 +140,15 @@ OPTIONS
 
   -h, --help                                       show CLI help
 
-  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The public key (in base 58) of the
-                                                   gatekeeper network that the gatekeeper belongs to.
+  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: tgnuXXNMDLK8dy7Xm1TdeGyc95MDym4bvAQCwcW21Bf] The public key
+                                                   (in base 58) of the gatekeeper network that the gatekeeper belongs
+                                                   to.
 
 EXAMPLE
   $ gateway issue EzZgkwaDrgycsiyGeCVRXXRcieE1fxhGMp829qwj5TMv2QJjjrzdPSrcZUuAH2KrEU61crWz49KnSLSzwjDUnLSV
 ```
 
-_See code: [dist/commands/issue.ts](https://github.com/identity-com/gatekeeper-lib/blob/v1.1.0/dist/commands/issue.ts)_
+_See code: [dist/commands/issue.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.1.2/dist/commands/issue.ts)_
 
 ## `gateway refresh GATEWAYTOKEN [EXPIRY]`
 
@@ -170,15 +172,16 @@ OPTIONS
 
   -h, --help                                       show CLI help
 
-  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The public key (in base 58) of the
-                                                   gatekeeper network that the gatekeeper belongs to.
+  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: tgnuXXNMDLK8dy7Xm1TdeGyc95MDym4bvAQCwcW21Bf] The public key
+                                                   (in base 58) of the gatekeeper network that the gatekeeper belongs
+                                                   to.
 
 EXAMPLE
   $ gateway refresh EzZgkwaDrgycsiyGeCVRXXRcieE1fxhGMp829qwj5TMv 54000
   Refreshed
 ```
 
-_See code: [dist/commands/refresh.ts](https://github.com/identity-com/gatekeeper-lib/blob/v1.1.0/dist/commands/refresh.ts)_
+_See code: [dist/commands/refresh.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.1.2/dist/commands/refresh.ts)_
 
 ## `gateway revoke GATEWAYTOKEN`
 
@@ -201,15 +204,16 @@ OPTIONS
 
   -h, --help                                       show CLI help
 
-  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The public key (in base 58) of the
-                                                   gatekeeper network that the gatekeeper belongs to.
+  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: tgnuXXNMDLK8dy7Xm1TdeGyc95MDym4bvAQCwcW21Bf] The public key
+                                                   (in base 58) of the gatekeeper network that the gatekeeper belongs
+                                                   to.
 
 EXAMPLE
   $ gateway revoke EzZgkwaDrgycsiyGeCVRXXRcieE1fxhGMp829qwj5TMv
   Revoked
 ```
 
-_See code: [dist/commands/revoke.ts](https://github.com/identity-com/gatekeeper-lib/blob/v1.1.0/dist/commands/revoke.ts)_
+_See code: [dist/commands/revoke.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.1.2/dist/commands/revoke.ts)_
 
 ## `gateway revoke-gatekeeper ADDRESS`
 
@@ -239,7 +243,7 @@ EXAMPLE
   $ gateway revoke-gatekeeper tgky5YfBseCvqehzsycwCG6rh2udA4w14MxZMnZz9Hp
 ```
 
-_See code: [dist/commands/revoke-gatekeeper.ts](https://github.com/identity-com/gatekeeper-lib/blob/v1.1.0/dist/commands/revoke-gatekeeper.ts)_
+_See code: [dist/commands/revoke-gatekeeper.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.1.2/dist/commands/revoke-gatekeeper.ts)_
 
 ## `gateway unfreeze GATEWAYTOKEN`
 
@@ -262,15 +266,16 @@ OPTIONS
 
   -h, --help                                       show CLI help
 
-  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The public key (in base 58) of the
-                                                   gatekeeper network that the gatekeeper belongs to.
+  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: tgnuXXNMDLK8dy7Xm1TdeGyc95MDym4bvAQCwcW21Bf] The public key
+                                                   (in base 58) of the gatekeeper network that the gatekeeper belongs
+                                                   to.
 
 EXAMPLE
   $ gateway unfreeze EzZgkwaDrgycsiyGeCVRXXRcieE1fxhGMp829qwj5TMv
   Unfrozen
 ```
 
-_See code: [dist/commands/unfreeze.ts](https://github.com/identity-com/gatekeeper-lib/blob/v1.1.0/dist/commands/unfreeze.ts)_
+_See code: [dist/commands/unfreeze.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.1.2/dist/commands/unfreeze.ts)_
 
 ## `gateway verify OWNER`
 
@@ -290,8 +295,9 @@ OPTIONS
 
   -h, --help                                       show CLI help
 
-  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The public key (in base 58) of the
-                                                   gatekeeper network that the gatekeeper belongs to.
+  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: tgnuXXNMDLK8dy7Xm1TdeGyc95MDym4bvAQCwcW21Bf] The public key
+                                                   (in base 58) of the gatekeeper network that the gatekeeper belongs
+                                                   to.
 
 EXAMPLE
   $ gateway verify EzZgkwaDrgycsiyGeCVRXXRcieE1fxhGMp829qwj5TMv
@@ -305,5 +311,5 @@ EXAMPLE
   }
 ```
 
-_See code: [dist/commands/verify.ts](https://github.com/identity-com/gatekeeper-lib/blob/v1.1.0/dist/commands/verify.ts)_
+_See code: [dist/commands/verify.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.1.2/dist/commands/verify.ts)_
 <!-- commandsstop -->

--- a/solana/gatekeeper-lib/docs/classes/GatekeeperNetworkService.html
+++ b/solana/gatekeeper-lib/docs/classes/GatekeeperNetworkService.html
@@ -112,7 +112,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/9610307/solana/gatekeeper-lib/src/service/GatekeeperNetworkService.ts#L19">service/GatekeeperNetworkService.ts:19</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/bad78eb/solana/gatekeeper-lib/src/service/GatekeeperNetworkService.ts#L25">service/GatekeeperNetworkService.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -158,13 +158,13 @@
 					<a name="addGatekeeper" class="tsd-anchor"></a>
 					<h3>add<wbr>Gatekeeper</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">add<wbr>Gatekeeper<span class="tsd-signature-symbol">(</span>gatekeeperAuthority<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">PublicKey</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">PublicKey</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">add<wbr>Gatekeeper<span class="tsd-signature-symbol">(</span>gatekeeperAuthority<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">PublicKey</span>, confirmOptions<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ConfirmOptions</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">PublicKey</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/9610307/solana/gatekeeper-lib/src/service/GatekeeperNetworkService.ts#L29">service/GatekeeperNetworkService.ts:29</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/bad78eb/solana/gatekeeper-lib/src/service/GatekeeperNetworkService.ts#L36">service/GatekeeperNetworkService.ts:36</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -176,6 +176,9 @@
 							<ul class="tsd-parameters">
 								<li>
 									<h5>gatekeeperAuthority: <span class="tsd-signature-type">PublicKey</span></h5>
+								</li>
+								<li>
+									<h5>confirmOptions: <span class="tsd-signature-type">ConfirmOptions</span><span class="tsd-signature-symbol"> = {}</span></h5>
 									<div class="tsd-comment tsd-typography">
 									</div>
 								</li>
@@ -194,7 +197,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/9610307/solana/gatekeeper-lib/src/service/GatekeeperNetworkService.ts#L83">service/GatekeeperNetworkService.ts:83</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/bad78eb/solana/gatekeeper-lib/src/service/GatekeeperNetworkService.ts#L98">service/GatekeeperNetworkService.ts:98</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/solana/gatekeeper-lib/docs/classes/GatekeeperService.html
+++ b/solana/gatekeeper-lib/docs/classes/GatekeeperService.html
@@ -116,7 +116,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/9610307/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L35">service/GatekeeperService.ts:35</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/bad78eb/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L41">service/GatekeeperService.ts:41</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -184,7 +184,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/9610307/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L196">service/GatekeeperService.ts:196</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/bad78eb/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L223">service/GatekeeperService.ts:223</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -208,13 +208,13 @@
 					<a name="freeze" class="tsd-anchor"></a>
 					<h3>freeze</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">freeze<span class="tsd-signature-symbol">(</span>gatewayTokenKey<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">PublicKey</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">GatewayToken</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">freeze<span class="tsd-signature-symbol">(</span>gatewayTokenKey<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">PublicKey</span>, confirmOptions<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ConfirmOptions</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">GatewayToken</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/9610307/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L140">service/GatekeeperService.ts:140</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/bad78eb/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L158">service/GatekeeperService.ts:158</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -226,6 +226,9 @@
 							<ul class="tsd-parameters">
 								<li>
 									<h5>gatewayTokenKey: <span class="tsd-signature-type">PublicKey</span></h5>
+								</li>
+								<li>
+									<h5>confirmOptions: <span class="tsd-signature-type">ConfirmOptions</span><span class="tsd-signature-symbol"> = {}</span></h5>
 									<div class="tsd-comment tsd-typography">
 									</div>
 								</li>
@@ -238,13 +241,13 @@
 					<a name="issue" class="tsd-anchor"></a>
 					<h3>issue</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">issue<span class="tsd-signature-symbol">(</span>recipient<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">PublicKey</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">GatewayToken</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">issue<span class="tsd-signature-symbol">(</span>recipient<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">PublicKey</span>, confirmOptions<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ConfirmOptions</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">GatewayToken</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/9610307/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L105">service/GatekeeperService.ts:105</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/bad78eb/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L114">service/GatekeeperService.ts:114</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -256,6 +259,9 @@
 							<ul class="tsd-parameters">
 								<li>
 									<h5>recipient: <span class="tsd-signature-type">PublicKey</span></h5>
+								</li>
+								<li>
+									<h5>confirmOptions: <span class="tsd-signature-type">ConfirmOptions</span><span class="tsd-signature-symbol"> = {}</span></h5>
 									<div class="tsd-comment tsd-typography">
 									</div>
 								</li>
@@ -268,13 +274,13 @@
 					<a name="revoke" class="tsd-anchor"></a>
 					<h3>revoke</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">revoke<span class="tsd-signature-symbol">(</span>gatewayTokenKey<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">PublicKey</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">GatewayToken</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">revoke<span class="tsd-signature-symbol">(</span>gatewayTokenKey<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">PublicKey</span>, confirmOptions<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ConfirmOptions</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">GatewayToken</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/9610307/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L113">service/GatekeeperService.ts:113</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/bad78eb/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L126">service/GatekeeperService.ts:126</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -286,6 +292,9 @@
 							<ul class="tsd-parameters">
 								<li>
 									<h5>gatewayTokenKey: <span class="tsd-signature-type">PublicKey</span></h5>
+								</li>
+								<li>
+									<h5>confirmOptions: <span class="tsd-signature-type">ConfirmOptions</span><span class="tsd-signature-symbol"> = {}</span></h5>
 									<div class="tsd-comment tsd-typography">
 									</div>
 								</li>
@@ -298,13 +307,13 @@
 					<a name="unfreeze" class="tsd-anchor"></a>
 					<h3>unfreeze</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">unfreeze<span class="tsd-signature-symbol">(</span>gatewayTokenKey<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">PublicKey</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">GatewayToken</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">unfreeze<span class="tsd-signature-symbol">(</span>gatewayTokenKey<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">PublicKey</span>, confirmOptions<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ConfirmOptions</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">GatewayToken</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/9610307/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L168">service/GatekeeperService.ts:168</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/bad78eb/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L191">service/GatekeeperService.ts:191</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -316,6 +325,9 @@
 							<ul class="tsd-parameters">
 								<li>
 									<h5>gatewayTokenKey: <span class="tsd-signature-type">PublicKey</span></h5>
+								</li>
+								<li>
+									<h5>confirmOptions: <span class="tsd-signature-type">ConfirmOptions</span><span class="tsd-signature-symbol"> = {}</span></h5>
 									<div class="tsd-comment tsd-typography">
 									</div>
 								</li>
@@ -328,13 +340,13 @@
 					<a name="updateExpiry" class="tsd-anchor"></a>
 					<h3>update<wbr>Expiry</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">update<wbr>Expiry<span class="tsd-signature-symbol">(</span>gatewayTokenKey<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">PublicKey</span>, expireTime<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">GatewayToken</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">update<wbr>Expiry<span class="tsd-signature-symbol">(</span>gatewayTokenKey<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">PublicKey</span>, expireTime<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span>, confirmOptions<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">ConfirmOptions</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">GatewayToken</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/9610307/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L207">service/GatekeeperService.ts:207</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/bad78eb/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L235">service/GatekeeperService.ts:235</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -349,6 +361,9 @@
 								</li>
 								<li>
 									<h5>expireTime: <span class="tsd-signature-type">number</span></h5>
+								</li>
+								<li>
+									<h5>confirmOptions: <span class="tsd-signature-type">ConfirmOptions</span><span class="tsd-signature-symbol"> = {}</span></h5>
 									<div class="tsd-comment tsd-typography">
 									</div>
 								</li>

--- a/solana/gatekeeper-lib/package.json
+++ b/solana/gatekeeper-lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@identity.com/solana-gatekeeper-lib",
   "description": "Library and CLI to manage Gateway Tokens",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "author": "dankelleher @dankelleher",
   "bin": {
     "gateway": "./bin/run"

--- a/solana/gatekeeper-lib/package.json
+++ b/solana/gatekeeper-lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@identity.com/solana-gatekeeper-lib",
   "description": "Library and CLI to manage Gateway Tokens",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "author": "dankelleher @dankelleher",
   "bin": {
     "gateway": "./bin/run"

--- a/solana/gatekeeper-lib/package.json
+++ b/solana/gatekeeper-lib/package.json
@@ -6,7 +6,7 @@
   "bin": {
     "gateway": "./bin/run"
   },
-  "bugs": "https://github.com/identity-com/ociv/issues",
+  "bugs": "https://github.com/identity-com/on-chain-identity-gateway/issues",
   "dependencies": {
     "@identity.com/solana-gateway-ts": "^0.3.0",
     "@oclif/command": "^1.8.0",

--- a/solana/gatekeeper-lib/src/service/GatekeeperNetworkService.ts
+++ b/solana/gatekeeper-lib/src/service/GatekeeperNetworkService.ts
@@ -1,4 +1,10 @@
-import { Keypair, Connection, PublicKey, Transaction } from "@solana/web3.js";
+import {
+  Keypair,
+  Connection,
+  PublicKey,
+  Transaction,
+  ConfirmOptions,
+} from "@solana/web3.js";
 import {
   addGatekeeper,
   getGatekeeperAccountKey,
@@ -25,8 +31,12 @@ export class GatekeeperNetworkService {
   /**
    * Add a gatekeeper to the network
    * @param gatekeeperAuthority
+   * @param confirmOptions
    */
-  async addGatekeeper(gatekeeperAuthority: PublicKey): Promise<PublicKey> {
+  async addGatekeeper(
+    gatekeeperAuthority: PublicKey,
+    confirmOptions: ConfirmOptions = {}
+  ): Promise<PublicKey> {
     const gatekeeperAccount = await getGatekeeperAccountKey(
       gatekeeperAuthority,
       this.gatekeeperNetwork.publicKey
@@ -44,6 +54,7 @@ export class GatekeeperNetworkService {
     await send(
       this.connection,
       transaction,
+      confirmOptions,
       this.payer,
       this.gatekeeperNetwork
     );
@@ -51,7 +62,10 @@ export class GatekeeperNetworkService {
     return gatekeeperAccount;
   }
 
-  async revokeGatekeeper(gatekeeperAuthority: PublicKey): Promise<PublicKey> {
+  async revokeGatekeeper(
+    gatekeeperAuthority: PublicKey,
+    confirmOptions: ConfirmOptions = {}
+  ): Promise<PublicKey> {
     const gatekeeperAccount = await getGatekeeperAccountKey(
       gatekeeperAuthority,
       this.gatekeeperNetwork.publicKey
@@ -69,6 +83,7 @@ export class GatekeeperNetworkService {
     await send(
       this.connection,
       transaction,
+      confirmOptions,
       this.payer,
       this.gatekeeperNetwork
     );

--- a/solana/gatekeeper-lib/src/service/GatekeeperService.ts
+++ b/solana/gatekeeper-lib/src/service/GatekeeperService.ts
@@ -1,4 +1,10 @@
-import { Connection, Keypair, PublicKey, Transaction } from "@solana/web3.js";
+import {
+  ConfirmOptions,
+  Connection,
+  Keypair,
+  PublicKey,
+  Transaction,
+} from "@solana/web3.js";
 import {
   freeze,
   GatewayToken,
@@ -62,7 +68,8 @@ export class GatekeeperService {
 
   private async issueVanilla(
     owner: PublicKey,
-    seed?: Uint8Array
+    seed?: Uint8Array,
+    confirmOptions: ConfirmOptions = {}
   ): Promise<GatewayToken> {
     const gatewayTokenKey = await getGatewayTokenKeyForOwner(
       owner,
@@ -91,6 +98,7 @@ export class GatekeeperService {
     await send(
       this.connection,
       transaction,
+      confirmOptions,
       this.payer,
       this.gatekeeperAuthority
     );
@@ -109,8 +117,12 @@ export class GatekeeperService {
   /**
    * Revoke the gateway token. The token must have been issued by a gatekeeper in the same network
    * @param gatewayTokenKey
+   * @param confirmOptions
    */
-  async revoke(gatewayTokenKey: PublicKey): Promise<GatewayToken> {
+  async revoke(
+    gatewayTokenKey: PublicKey,
+    confirmOptions: ConfirmOptions = {}
+  ): Promise<GatewayToken> {
     const gatekeeperAccount = await getGatekeeperAccountKey(
       this.gatekeeperAuthority.publicKey,
       this.gatekeeperNetwork
@@ -126,6 +138,7 @@ export class GatekeeperService {
     await send(
       this.connection,
       transaction,
+      confirmOptions,
       this.payer,
       this.gatekeeperAuthority
     );
@@ -136,8 +149,12 @@ export class GatekeeperService {
   /**
    * Freeze the gateway token. The token must have been issued by this gatekeeper.
    * @param gatewayTokenKey
+   * @param confirmOptions
    */
-  async freeze(gatewayTokenKey: PublicKey): Promise<GatewayToken> {
+  async freeze(
+    gatewayTokenKey: PublicKey,
+    confirmOptions: ConfirmOptions = {}
+  ): Promise<GatewayToken> {
     const gatekeeperAccount = await getGatekeeperAccountKey(
       this.gatekeeperAuthority.publicKey,
       this.gatekeeperNetwork
@@ -154,6 +171,7 @@ export class GatekeeperService {
     await send(
       this.connection,
       transaction,
+      confirmOptions,
       this.payer,
       this.gatekeeperAuthority
     );
@@ -164,8 +182,12 @@ export class GatekeeperService {
   /**
    * Unfreeze the gateway token. The token must have been issued by this gatekeeper.
    * @param gatewayTokenKey
+   * @param confirmOptions
    */
-  async unfreeze(gatewayTokenKey: PublicKey): Promise<GatewayToken> {
+  async unfreeze(
+    gatewayTokenKey: PublicKey,
+    confirmOptions: ConfirmOptions = {}
+  ): Promise<GatewayToken> {
     const gatekeeperAccount = await getGatekeeperAccountKey(
       this.gatekeeperAuthority.publicKey,
       this.gatekeeperNetwork
@@ -182,6 +204,7 @@ export class GatekeeperService {
     await send(
       this.connection,
       transaction,
+      confirmOptions,
       this.payer,
       this.gatekeeperAuthority
     );
@@ -203,10 +226,12 @@ export class GatekeeperService {
    * Update the expiry time of the gateway token. The token must have been issued by this gatekeeper.
    * @param gatewayTokenKey
    * @param expireTime
+   * @param confirmOptions
    */
   async updateExpiry(
     gatewayTokenKey: PublicKey,
-    expireTime: number
+    expireTime: number,
+    confirmOptions: ConfirmOptions = {}
   ): Promise<GatewayToken> {
     const gatekeeperAccount = await getGatekeeperAccountKey(
       this.gatekeeperAuthority.publicKey,
@@ -224,6 +249,7 @@ export class GatekeeperService {
     await send(
       this.connection,
       transaction,
+      confirmOptions,
       this.payer,
       this.gatekeeperAuthority
     );

--- a/solana/gatekeeper-lib/src/service/GatekeeperService.ts
+++ b/solana/gatekeeper-lib/src/service/GatekeeperService.ts
@@ -109,9 +109,13 @@ export class GatekeeperService {
   /**
    * Issue a token to this recipient
    * @param recipient
+   * @param confirmOptions
    */
-  issue(recipient: PublicKey): Promise<GatewayToken> {
-    return this.issueVanilla(recipient);
+  issue(
+    recipient: PublicKey,
+    confirmOptions: ConfirmOptions = {}
+  ): Promise<GatewayToken> {
+    return this.issueVanilla(recipient, undefined, confirmOptions);
   }
 
   /**

--- a/solana/gatekeeper-lib/src/util/connection.ts
+++ b/solana/gatekeeper-lib/src/util/connection.ts
@@ -1,6 +1,7 @@
 import {
   Cluster,
   clusterApiUrl,
+  ConfirmOptions,
   Connection,
   Keypair,
   sendAndConfirmTransaction,
@@ -32,10 +33,11 @@ export const getConnection = (
 export const send = (
   connection: Connection,
   transaction: Transaction,
+  options: ConfirmOptions = {},
   ...signers: Keypair[]
 ): Promise<TransactionSignature> =>
   sendAndConfirmTransaction(connection, transaction, signers, {
     skipPreflight: false,
     commitment: SOLANA_COMMITMENT,
-    preflightCommitment: "recent",
+    ...options,
   });


### PR DESCRIPTION
Allow configuration of solana transactions, e.g. to specify a different commitment level