### PR TITLE
IDCOM-1596 Add separate field to RetryConfig for the healthcheck timeout

### DIFF
--- a/.github/workflows/solana-rust.yml
+++ b/.github/workflows/solana-rust.yml
@@ -76,7 +76,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             ./solana/target
-          key: cargo-build-${{ hashFiles('solana/Cargo.lock') }}
+          key: cargo-build-v2-${{ hashFiles('solana/Cargo.lock') }}
 
       - name: Cache Solana version
         uses: actions/cache@v2

--- a/.github/workflows/solana-ts.yml
+++ b/.github/workflows/solana-ts.yml
@@ -78,7 +78,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             ./solana/target
-          key: cargo-build-${{ hashFiles('solana/Cargo.lock') }}
+          key: cargo-build-v2-${{ hashFiles('solana/Cargo.lock') }}
 
       - name: Cache Solana version
         uses: actions/cache@v2

--- a/solana/gatekeeper-lib/README.md
+++ b/solana/gatekeeper-lib/README.md
@@ -19,7 +19,7 @@ $ npm install -g @identity.com/solana-gatekeeper-lib
 $ gateway COMMAND
 running command...
 $ gateway (-v|--version|version)
-@identity.com/solana-gatekeeper-lib/1.4.3 darwin-x64 node-v14.18.2
+@identity.com/solana-gatekeeper-lib/1.4.4-beta1 darwin-x64 node-v14.18.2
 $ gateway --help [COMMAND]
 USAGE
   $ gateway COMMAND
@@ -66,7 +66,7 @@ EXAMPLE
   $ gateway add-gatekeeper tgky5YfBseCvqehzsycwCG6rh2udA4w14MxZMnZz9Hp
 ```
 
-_See code: [dist/commands/add-gatekeeper.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.4.3/dist/commands/add-gatekeeper.ts)_
+_See code: [dist/commands/add-gatekeeper.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.4.4-beta1/dist/commands/add-gatekeeper.ts)_
 
 ## `gateway freeze GATEWAYTOKEN`
 
@@ -89,15 +89,16 @@ OPTIONS
 
   -h, --help                                       show CLI help
 
-  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The public key (in base 58) of the
-                                                   gatekeeper network that the gatekeeper belongs to.
+  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: tgnuXXNMDLK8dy7Xm1TdeGyc95MDym4bvAQCwcW21Bf] The public key
+                                                   (in base 58) of the gatekeeper network that the gatekeeper belongs
+                                                   to.
 
 EXAMPLE
   $ gateway freeze EzZgkwaDrgycsiyGeCVRXXRcieE1fxhGMp829qwj5TMv
   Frozen
 ```
 
-_See code: [dist/commands/freeze.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.4.3/dist/commands/freeze.ts)_
+_See code: [dist/commands/freeze.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.4.4-beta1/dist/commands/freeze.ts)_
 
 ## `gateway help [COMMAND]`
 
@@ -139,14 +140,15 @@ OPTIONS
 
   -h, --help                                       show CLI help
 
-  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The public key (in base 58) of the
-                                                   gatekeeper network that the gatekeeper belongs to.
+  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: tgnuXXNMDLK8dy7Xm1TdeGyc95MDym4bvAQCwcW21Bf] The public key
+                                                   (in base 58) of the gatekeeper network that the gatekeeper belongs
+                                                   to.
 
 EXAMPLE
   $ gateway issue EzZgkwaDrgycsiyGeCVRXXRcieE1fxhGMp829qwj5TMv2QJjjrzdPSrcZUuAH2KrEU61crWz49KnSLSzwjDUnLSV
 ```
 
-_See code: [dist/commands/issue.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.4.3/dist/commands/issue.ts)_
+_See code: [dist/commands/issue.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.4.4-beta1/dist/commands/issue.ts)_
 
 ## `gateway refresh GATEWAYTOKEN [EXPIRY]`
 
@@ -170,15 +172,16 @@ OPTIONS
 
   -h, --help                                       show CLI help
 
-  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The public key (in base 58) of the
-                                                   gatekeeper network that the gatekeeper belongs to.
+  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: tgnuXXNMDLK8dy7Xm1TdeGyc95MDym4bvAQCwcW21Bf] The public key
+                                                   (in base 58) of the gatekeeper network that the gatekeeper belongs
+                                                   to.
 
 EXAMPLE
   $ gateway refresh EzZgkwaDrgycsiyGeCVRXXRcieE1fxhGMp829qwj5TMv 54000
   Refreshed
 ```
 
-_See code: [dist/commands/refresh.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.4.3/dist/commands/refresh.ts)_
+_See code: [dist/commands/refresh.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.4.4-beta1/dist/commands/refresh.ts)_
 
 ## `gateway revoke GATEWAYTOKEN`
 
@@ -201,15 +204,16 @@ OPTIONS
 
   -h, --help                                       show CLI help
 
-  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The public key (in base 58) of the
-                                                   gatekeeper network that the gatekeeper belongs to.
+  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: tgnuXXNMDLK8dy7Xm1TdeGyc95MDym4bvAQCwcW21Bf] The public key
+                                                   (in base 58) of the gatekeeper network that the gatekeeper belongs
+                                                   to.
 
 EXAMPLE
   $ gateway revoke EzZgkwaDrgycsiyGeCVRXXRcieE1fxhGMp829qwj5TMv
   Revoked
 ```
 
-_See code: [dist/commands/revoke.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.4.3/dist/commands/revoke.ts)_
+_See code: [dist/commands/revoke.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.4.4-beta1/dist/commands/revoke.ts)_
 
 ## `gateway revoke-gatekeeper ADDRESS`
 
@@ -239,7 +243,7 @@ EXAMPLE
   $ gateway revoke-gatekeeper tgky5YfBseCvqehzsycwCG6rh2udA4w14MxZMnZz9Hp
 ```
 
-_See code: [dist/commands/revoke-gatekeeper.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.4.3/dist/commands/revoke-gatekeeper.ts)_
+_See code: [dist/commands/revoke-gatekeeper.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.4.4-beta1/dist/commands/revoke-gatekeeper.ts)_
 
 ## `gateway unfreeze GATEWAYTOKEN`
 
@@ -262,15 +266,16 @@ OPTIONS
 
   -h, --help                                       show CLI help
 
-  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The public key (in base 58) of the
-                                                   gatekeeper network that the gatekeeper belongs to.
+  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: tgnuXXNMDLK8dy7Xm1TdeGyc95MDym4bvAQCwcW21Bf] The public key
+                                                   (in base 58) of the gatekeeper network that the gatekeeper belongs
+                                                   to.
 
 EXAMPLE
   $ gateway unfreeze EzZgkwaDrgycsiyGeCVRXXRcieE1fxhGMp829qwj5TMv
   Unfrozen
 ```
 
-_See code: [dist/commands/unfreeze.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.4.3/dist/commands/unfreeze.ts)_
+_See code: [dist/commands/unfreeze.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.4.4-beta1/dist/commands/unfreeze.ts)_
 
 ## `gateway verify OWNER`
 
@@ -290,8 +295,9 @@ OPTIONS
 
   -h, --help                                       show CLI help
 
-  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The public key (in base 58) of the
-                                                   gatekeeper network that the gatekeeper belongs to.
+  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: tgnuXXNMDLK8dy7Xm1TdeGyc95MDym4bvAQCwcW21Bf] The public key
+                                                   (in base 58) of the gatekeeper network that the gatekeeper belongs
+                                                   to.
 
 EXAMPLE
   $ gateway verify EzZgkwaDrgycsiyGeCVRXXRcieE1fxhGMp829qwj5TMv
@@ -305,5 +311,5 @@ EXAMPLE
   }
 ```
 
-_See code: [dist/commands/verify.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.4.3/dist/commands/verify.ts)_
+_See code: [dist/commands/verify.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v1.4.4-beta1/dist/commands/verify.ts)_
 <!-- commandsstop -->

--- a/solana/gatekeeper-lib/package.json
+++ b/solana/gatekeeper-lib/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@identity.com/solana-gatekeeper-lib",
   "description": "Library and CLI to manage Gateway Tokens",
-  "version": "1.4.3",
+  "version": "1.4.4-beta1",
   "author": "dankelleher @dankelleher",
   "bin": {
     "gateway": "./bin/run"
   },
   "bugs": "https://github.com/identity-com/on-chain-identity-gateway/issues",
   "dependencies": {
-    "@identity.com/solana-gateway-ts": "^0.4.3",
+    "@identity.com/solana-gateway-ts": "^0.4.4-beta2",
     "@oclif/command": "^1.8.0",
     "@oclif/config": "^1.17.0",
     "@oclif/plugin-help": "^3.2.2",

--- a/solana/gateway-ts/package.json
+++ b/solana/gateway-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/solana-gateway-ts",
-  "version": "0.4.3",
+  "version": "0.4.4-beta1",
   "description": "Typescript adapters for interacting with Solana gateway program",
   "main": "dist/index",
   "types": "dist/index",

--- a/solana/gateway-ts/package.json
+++ b/solana/gateway-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/solana-gateway-ts",
-  "version": "0.4.4-beta1",
+  "version": "0.4.4-beta2",
   "description": "Typescript adapters for interacting with Solana gateway program",
   "main": "dist/index",
   "types": "dist/index",

--- a/solana/gateway-ts/src/lib/util.ts
+++ b/solana/gateway-ts/src/lib/util.ts
@@ -34,6 +34,7 @@ export type RetryConfig = {
   retryCount: number;
   exponentialFactor: number;
   timeouts: {
+    healthcheck: number;
     processed: number;
     confirmed: number;
     finalized: number;

--- a/solana/gateway-ts/src/lib/util.ts
+++ b/solana/gateway-ts/src/lib/util.ts
@@ -52,6 +52,7 @@ export const defaultRetryConfig = {
 };
 
 export const runFunctionWithRetry = async (
+  methodName: string, // for logging purposes so we know which call this was
   fn: () => Promise<unknown>,
   commitment: Commitment,
   customRetryConfig: DeepPartial<RetryConfig>
@@ -92,26 +93,34 @@ export const runFunctionWithRetry = async (
 
   let currentAttempt = 0;
 
-  return retry(
-    async () => {
-      currentAttempt++;
-      console.log(
-        `Trying Solana blockchain call (attempt ${currentAttempt} of ${
-          retryConfig.retryCount + 1
-        })`,
-        { timeout }
-      );
-      const timeoutPromise = new Promise((_resolve, reject) =>
-        setTimeout(() => reject(new Error("timeout")), timeout)
-      );
-      const blockchainPromise = fn();
-      return Promise.race([blockchainPromise, timeoutPromise]);
-    },
-    {
-      retries: retryCount,
-      factor: expFactor,
-    }
-  );
+  try {
+    return await retry(
+      async () => {
+        currentAttempt++;
+        console.log(
+          `Trying Solana connection method '${methodName}' (attempt ${currentAttempt} of ${
+            retryConfig.retryCount + 1
+          })`,
+          { timeout }
+        );
+        const timeoutPromise = new Promise((_resolve, reject) =>
+          setTimeout(() => reject(new Error("timeout")), timeout)
+        );
+        const blockchainPromise = fn();
+        return Promise.race([blockchainPromise, timeoutPromise]);
+      },
+      {
+        retries: retryCount,
+        factor: expFactor,
+      }
+    );
+  } catch (err) {
+    console.error(
+      `Retries exhausted in Solana connection method '${methodName}' .`,
+      { error: err }
+    );
+    throw err;
+  }
 };
 
 export const proxyConnectionWithRetry = (
@@ -130,6 +139,7 @@ export const proxyConnectionWithRetry = (
             const fn = async () =>
               target.sendTransaction(transaction, signers, options);
             return runFunctionWithRetry(
+              "sendTransaction",
               fn,
               SOLANA_COMMITMENT,
               customRetryConfig
@@ -143,6 +153,7 @@ export const proxyConnectionWithRetry = (
             const fn = async () =>
               target.confirmTransaction(signature, commitment);
             return runFunctionWithRetry(
+              "confirmTransaction",
               fn,
               SOLANA_COMMITMENT,
               customRetryConfig
@@ -164,6 +175,7 @@ export const proxyConnectionWithRetry = (
             const fn = async () =>
               target.getProgramAccounts(programId, configOrCommitment);
             return runFunctionWithRetry(
+              "getProgramAccounts",
               fn,
               SOLANA_COMMITMENT,
               customRetryConfig
@@ -181,6 +193,7 @@ export const proxyConnectionWithRetry = (
           ): Promise<AccountInfo<Buffer> | null> => {
             const fn = async () => target.getAccountInfo(publicKey, commitment);
             return runFunctionWithRetry(
+              "getAccountInfo",
               fn,
               SOLANA_COMMITMENT,
               customRetryConfig
@@ -193,7 +206,12 @@ export const proxyConnectionWithRetry = (
     },
     apply(target: any, thisArg, argumentsList) {
       const fn = async () => target.apply(thisArg, argumentsList);
-      return runFunctionWithRetry(fn, SOLANA_COMMITMENT, customRetryConfig);
+      return runFunctionWithRetry(
+        "apply",
+        fn,
+        SOLANA_COMMITMENT,
+        customRetryConfig
+      );
     },
   };
   return new Proxy<Connection>(originalConnection, proxyHandler);


### PR DESCRIPTION
- Add separate field to RetryConfig for the healthcheck timeouts, so they can be shorter than the 'send transaction' timeouts.
- Improve logging around solana retries...add a "retries exhausted" and include the name of the Connection method that was being processed in retry logs.
- Change the solana cache key to `-v2-` in CI to invalidate the cache due to recent Solana program updates.