### PR TITLE
IDCOM-1740 Expiry tolerance

### DIFF
--- a/solana/Cargo.lock
+++ b/solana/Cargo.lock
@@ -2233,7 +2233,7 @@ dependencies = [
 
 [[package]]
 name = "solana-gateway"
-version = "0.0.4"
+version = "0.1.0"
 dependencies = [
  "bitflags",
  "borsh",

--- a/solana/integration-lib/Cargo.toml
+++ b/solana/integration-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-gateway"
-version = "0.0.4"
+version = "0.1.0"
 description = "Solana on-chain identity gateway"
 repository = "https://github.com/identity-com/on-chain-identity-gateway"
 authors = ["Identity.com <daniel@identity.com>"]

--- a/solana/integration-lib/src/error.rs
+++ b/solana/integration-lib/src/error.rs
@@ -40,6 +40,10 @@ pub enum GatewayError {
     /// The account is not owned by the gateway program
     #[error("The account is not owned by the gateway program")]
     IncorrectProgramId,
+
+    /// The gateway token has expired
+    #[error("The gateway token has expired")]
+    TokenExpired,
 }
 impl From<GatewayError> for ProgramError {
     fn from(e: GatewayError) -> Self {

--- a/solana/integration-lib/src/lib.rs
+++ b/solana/integration-lib/src/lib.rs
@@ -7,6 +7,7 @@ pub mod borsh;
 pub mod instruction;
 pub mod networks;
 pub mod state;
+mod test_utils;
 
 use crate::instruction::expire_token;
 use crate::state::{GatewayTokenAccess, GatewayTokenFunctions, InPlaceGatewayToken};
@@ -24,6 +25,22 @@ use std::str::FromStr;
 
 // Session gateway tokens, that have a lamport balance that exceeds this value, are rejected
 const MAX_SESSION_TOKEN_BALANCE: u64 = 0;
+
+/// Options to configure how a gateway token is considered valid. Typically, integrators should
+/// use the default options.
+#[derive(Copy, Clone, Debug, PartialEq, Default)]
+pub struct VerificationOptions {
+    /// If true, consider an expired token as invalid. Defaults to true
+    check_expiry: bool,
+    /// Number of seconds to allow a token to have expired by, for it still to be counted as active.
+    /// Defaults to 0. Must be set if check_expiry is true.
+    expiry_tolerance_seconds: Option<u32>
+}
+
+pub const DEFAULT_VERIFICATION_OPTIONS:VerificationOptions = VerificationOptions {
+    check_expiry: true,
+    expiry_tolerance_seconds: Some(0),
+};
 
 pub struct Gateway {}
 impl Gateway {
@@ -66,7 +83,9 @@ impl Gateway {
         expected_owner: &Pubkey,
         expected_gatekeeper_network_key: &Pubkey,
         gateway_token_account_balance: u64,
+        options: Option<VerificationOptions>,
     ) -> Result<(), GatewayError> {
+        let verification_options = options.unwrap_or(DEFAULT_VERIFICATION_OPTIONS);
         if expected_owner != gateway_token.owner_wallet() {
             msg!(
                 "Gateway token does not have the correct owner. Expected: {} Was: {}",
@@ -95,9 +114,14 @@ impl Gateway {
             return Err(GatewayError::InvalidSessionToken);
         }
 
-        if !gateway_token.is_valid() {
-            msg!("Gateway token is invalid. It has either been revoked or frozen, or has expired");
+        if !gateway_token.is_valid_state() {
+            msg!("Gateway token is invalid. It has either been revoked or frozen");
             return Err(GatewayError::TokenRevoked);
+        }
+        
+        if verification_options.check_expiry && gateway_token.has_expired(verification_options.expiry_tolerance_seconds.unwrap_or(0)) {
+            msg!("Gateway token has expired");
+            return Err(GatewayError::TokenExpired);
         }
 
         Ok(())
@@ -117,7 +141,7 @@ impl Gateway {
         }
     }
 
-    /// Verifies the gateway token accout parses to a valid gateway token,
+    /// Verifies the gateway token account parses to a valid gateway token,
     /// belongs to the expected owner,
     /// is signed by the gatekeeper,
     /// and is not revoked.
@@ -125,6 +149,7 @@ impl Gateway {
         gateway_token_info: &AccountInfo,
         expected_owner: &Pubkey,
         expected_gatekeeper_key: &Pubkey,
+        options: Option<VerificationOptions>,
     ) -> Result<(), GatewayError> {
         if gateway_token_info.owner.ne(&Gateway::program_id()) {
             return Err(GatewayError::IncorrectProgramId);
@@ -138,6 +163,7 @@ impl Gateway {
                 expected_owner,
                 expected_gatekeeper_key,
                 gateway_token_info.lamports.borrow().as_(),
+                options,
             ),
             Err(_) => gateway_token_result.map(|_| ()),
         }
@@ -181,6 +207,22 @@ impl Gateway {
 pub mod tests {
     use super::*;
     use std::{cell::RefCell, rc::Rc};
+    use crate::test_utils::{init, now};
+
+    fn expired_gateway_token() -> GatewayToken {
+        let mut token = GatewayToken {
+            features: 0,
+            parent_gateway_token: None,
+            owner_wallet: Default::default(),
+            owner_identity: None,
+            gatekeeper_network: Default::default(),
+            issuing_gatekeeper: Default::default(),
+            state: Default::default(),
+            expire_time: None
+        };
+        token.set_expire_time(0); // 1.1.1970 is definitely in the past
+        token
+    }
 
     #[test]
     fn verify_gateway_token_account_info_fails_on_incorrect_program_id() {
@@ -199,11 +241,61 @@ pub mod tests {
             &account_info,
             &Default::default(),
             &Default::default(),
+            None
         );
 
         assert!(matches!(
             verify_result,
             Err(GatewayError::IncorrectProgramId)
         ))
+    }
+
+    #[test]
+    fn verify_gateway_token_account_info_passes_an_expired_token_if_check_expiry_is_off() {
+        init();
+        let token = expired_gateway_token();
+        let verify_result = Gateway::verify_gateway_token(
+            &token,
+            &Default::default(),
+            &Default::default(),
+            0,
+            Some(VerificationOptions { check_expiry: false, ..Default::default() })
+        );
+
+        assert!(matches!(verify_result,Ok(())))
+    }
+
+    #[test]
+    fn verify_gateway_token_account_info_fails_an_expired_token_if_check_expiry_is_on() {
+        init();
+        let token = expired_gateway_token();
+        let verify_result = Gateway::verify_gateway_token(
+            &token,
+            &Default::default(),
+            &Default::default(),
+            0,
+            None
+        );
+
+        assert!(matches!(
+            verify_result,
+            Err(GatewayError::TokenExpired)
+        ))
+    }
+
+    #[test]
+    fn verify_gateway_token_account_info_passes_an_expired_token_if_it_is_within_tolerance() {
+        init();
+        let mut token = expired_gateway_token();
+        token.set_expire_time(now() - 10);
+        let verify_result = Gateway::verify_gateway_token(
+            &token,
+            &Default::default(),
+            &Default::default(),
+            0,
+            Some(VerificationOptions { check_expiry: true, expiry_tolerance_seconds: Some(60) })
+        );
+
+        assert!(matches!(verify_result,Ok(())))
     }
 }

--- a/solana/integration-lib/src/lib.rs
+++ b/solana/integration-lib/src/lib.rs
@@ -34,10 +34,10 @@ pub struct VerificationOptions {
     check_expiry: bool,
     /// Number of seconds to allow a token to have expired by, for it still to be counted as active.
     /// Defaults to 0. Must be set if check_expiry is true.
-    expiry_tolerance_seconds: Option<u32>
+    expiry_tolerance_seconds: Option<u32>,
 }
 
-pub const DEFAULT_VERIFICATION_OPTIONS:VerificationOptions = VerificationOptions {
+pub const DEFAULT_VERIFICATION_OPTIONS: VerificationOptions = VerificationOptions {
     check_expiry: true,
     expiry_tolerance_seconds: Some(0),
 };
@@ -118,8 +118,10 @@ impl Gateway {
             msg!("Gateway token is invalid. It has either been revoked or frozen");
             return Err(GatewayError::TokenRevoked);
         }
-        
-        if verification_options.check_expiry && gateway_token.has_expired(verification_options.expiry_tolerance_seconds.unwrap_or(0)) {
+
+        if verification_options.check_expiry
+            && gateway_token.has_expired(verification_options.expiry_tolerance_seconds.unwrap_or(0))
+        {
             msg!("Gateway token has expired");
             return Err(GatewayError::TokenExpired);
         }
@@ -206,8 +208,8 @@ impl Gateway {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use std::{cell::RefCell, rc::Rc};
     use crate::test_utils::{init, now};
+    use std::{cell::RefCell, rc::Rc};
 
     fn expired_gateway_token() -> GatewayToken {
         let mut token = GatewayToken {
@@ -218,7 +220,7 @@ pub mod tests {
             gatekeeper_network: Default::default(),
             issuing_gatekeeper: Default::default(),
             state: Default::default(),
-            expire_time: None
+            expire_time: None,
         };
         token.set_expire_time(0); // 1.1.1970 is definitely in the past
         token
@@ -241,7 +243,7 @@ pub mod tests {
             &account_info,
             &Default::default(),
             &Default::default(),
-            None
+            None,
         );
 
         assert!(matches!(
@@ -259,10 +261,13 @@ pub mod tests {
             &Default::default(),
             &Default::default(),
             0,
-            Some(VerificationOptions { check_expiry: false, ..Default::default() })
+            Some(VerificationOptions {
+                check_expiry: false,
+                ..Default::default()
+            }),
         );
 
-        assert!(matches!(verify_result,Ok(())))
+        assert!(matches!(verify_result, Ok(())))
     }
 
     #[test]
@@ -274,13 +279,10 @@ pub mod tests {
             &Default::default(),
             &Default::default(),
             0,
-            None
+            None,
         );
 
-        assert!(matches!(
-            verify_result,
-            Err(GatewayError::TokenExpired)
-        ))
+        assert!(matches!(verify_result, Err(GatewayError::TokenExpired)))
     }
 
     #[test]
@@ -293,9 +295,12 @@ pub mod tests {
             &Default::default(),
             &Default::default(),
             0,
-            Some(VerificationOptions { check_expiry: true, expiry_tolerance_seconds: Some(60) })
+            Some(VerificationOptions {
+                check_expiry: true,
+                expiry_tolerance_seconds: Some(60),
+            }),
         );
 
-        assert!(matches!(verify_result,Ok(())))
+        assert!(matches!(verify_result, Ok(())))
     }
 }

--- a/solana/integration-lib/src/state.rs
+++ b/solana/integration-lib/src/state.rs
@@ -3,7 +3,6 @@ use crate::networks::GATEWAY_NETWORKS;
 use crate::Gateway;
 use std::convert::TryInto;
 use std::mem::{size_of, transmute};
-use solana_program::msg;
 use {
     borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
     sol_did::validate_owner,
@@ -478,7 +477,7 @@ pub trait GatewayTokenFunctions: GatewayTokenAccess {
     fn has_expired(&self, tolerance: u32) -> bool {
         self.has_feature(Feature::Expirable) && before_now(self.expire_time().unwrap(), tolerance)
     }
-    
+
     /// Checks if the exotic gateway token is in a valid state (not inactive or expired)
     /// Note, this does not check association to any wallet.
     fn is_valid_exotic(&self, did: &AccountInfo, signers: &[&AccountInfo]) -> bool {
@@ -592,17 +591,14 @@ impl CompatibleTransactionDetails for SimpleTransactionDetails {
 #[cfg(test)]
 pub mod tests {
     use super::*;
+    use crate::test_utils::{init, now};
     use rand::{CryptoRng, Rng, RngCore, SeedableRng};
     use rand_chacha::ChaCha20Rng;
     use sol_did::state::{SolData, VerificationMethod};
     use solana_sdk::signature::{Keypair, Signer};
     use std::array::IntoIter;
     use std::iter::FusedIterator;
-    use std::{
-        cell::RefCell,
-        rc::Rc,
-    };
-    use crate::test_utils::{init, now};
+    use std::{cell::RefCell, rc::Rc};
 
     fn stub_vanilla_gateway_token() -> GatewayToken {
         GatewayToken {

--- a/solana/integration-lib/src/test_utils.rs
+++ b/solana/integration-lib/src/test_utils.rs
@@ -1,7 +1,7 @@
-use std::sync::Once;
-use std::time::{SystemTime, UNIX_EPOCH};
 use solana_program::clock::{Clock, UnixTimestamp};
 use solana_program::program_stubs;
+use std::sync::Once;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 static INIT_TESTS: Once = Once::new();
 

--- a/solana/integration-lib/src/test_utils.rs
+++ b/solana/integration-lib/src/test_utils.rs
@@ -1,0 +1,45 @@
+use std::sync::Once;
+use std::time::{SystemTime, UNIX_EPOCH};
+use solana_program::clock::{Clock, UnixTimestamp};
+use solana_program::program_stubs;
+
+static INIT_TESTS: Once = Once::new();
+
+// Get the current unix timestamp from SystemTime
+pub fn now() -> UnixTimestamp {
+    let start = SystemTime::now();
+    let now = start
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards");
+
+    now.as_secs() as UnixTimestamp
+}
+
+// Create stubs for anything we need that is provided by the solana runtime
+struct TestSyscallStubs {}
+impl program_stubs::SyscallStubs for TestSyscallStubs {
+    // create a stub clock object and set it at the provided address
+    fn sol_get_clock_sysvar(&self, var_addr: *mut u8) -> u64 {
+        // we only need the unix_timestamp
+        let stub_clock = Clock {
+            slot: 0,
+            epoch_start_timestamp: 0,
+            epoch: 0,
+            leader_schedule_epoch: 0,
+            unix_timestamp: now(),
+        };
+
+        // rust magic
+        unsafe {
+            *(var_addr as *mut _ as *mut Clock) = stub_clock;
+        }
+
+        0
+    }
+}
+// Inject stubs into the solana program singleton
+pub fn init() {
+    INIT_TESTS.call_once(|| {
+        program_stubs::set_syscall_stubs(Box::new(TestSyscallStubs {}));
+    });
+}


### PR DESCRIPTION
Solana Integration Lib: Allow ignoring expiry or setting a tolerance value when verifying a token. [API Change]