### PR TITLE
IDCOM-1741 Remove preflightCommitment from sent tx'es

### DIFF
--- a/solana/gatekeeper-lib/README.md
+++ b/solana/gatekeeper-lib/README.md
@@ -19,7 +19,7 @@ $ npm install -g @identity.com/solana-gatekeeper-lib
 $ gateway COMMAND
 running command...
 $ gateway (-v|--version|version)
-@identity.com/solana-gatekeeper-lib/3.1.1-beta1 darwin-x64 node-v14.18.1
+@identity.com/solana-gatekeeper-lib/3.1.1 darwin-x64 node-v14.18.2
 $ gateway --help [COMMAND]
 USAGE
   $ gateway COMMAND
@@ -28,18 +28,15 @@ USAGE
 <!-- usagestop -->
 # Commands
 <!-- commands -->
-- [gatekeeper-lib](#gatekeeper-lib)
-- [Usage](#usage)
-- [Commands](#commands)
-  - [`gateway add-gatekeeper ADDRESS`](#gateway-add-gatekeeper-address)
-  - [`gateway freeze GATEWAYTOKEN`](#gateway-freeze-gatewaytoken)
-  - [`gateway help [COMMAND]`](#gateway-help-command)
-  - [`gateway issue ADDRESS`](#gateway-issue-address)
-  - [`gateway refresh GATEWAYTOKEN [EXPIRY]`](#gateway-refresh-gatewaytoken-expiry)
-  - [`gateway revoke GATEWAYTOKEN`](#gateway-revoke-gatewaytoken)
-  - [`gateway revoke-gatekeeper ADDRESS`](#gateway-revoke-gatekeeper-address)
-  - [`gateway unfreeze GATEWAYTOKEN`](#gateway-unfreeze-gatewaytoken)
-  - [`gateway verify OWNER`](#gateway-verify-owner)
+* [`gateway add-gatekeeper ADDRESS`](#gateway-add-gatekeeper-address)
+* [`gateway freeze GATEWAYTOKEN`](#gateway-freeze-gatewaytoken)
+* [`gateway help [COMMAND]`](#gateway-help-command)
+* [`gateway issue ADDRESS`](#gateway-issue-address)
+* [`gateway refresh GATEWAYTOKEN [EXPIRY]`](#gateway-refresh-gatewaytoken-expiry)
+* [`gateway revoke GATEWAYTOKEN`](#gateway-revoke-gatewaytoken)
+* [`gateway revoke-gatekeeper ADDRESS`](#gateway-revoke-gatekeeper-address)
+* [`gateway unfreeze GATEWAYTOKEN`](#gateway-unfreeze-gatewaytoken)
+* [`gateway verify OWNER`](#gateway-verify-owner)
 
 ## `gateway add-gatekeeper ADDRESS`
 
@@ -57,19 +54,19 @@ OPTIONS
                                                    cluster to target: mainnet-beta, testnet, devnet, civicnet, localnet.
                                                    Alternatively, set the environment variable SOLANA_CLUSTER
 
-  -g, --gatekeeperKey=gatekeeperKey                [default: 'tgnuXXNMDLK8dy7Xm1TdeGyc95MDym4bvAQCwcW21Bf'] The private key file for the gatekeeper
+  -g, --gatekeeperKey=gatekeeperKey                [default: [object Object]] The private key file for the gatekeeper
                                                    authority
 
   -h, --help                                       show CLI help
 
-  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: 'tgnuXXNMDLK8dy7Xm1TdeGyc95MDym4bvAQCwcW21Bf'] The private key file for the gatekeeper
+  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The private key file for the gatekeeper
                                                    authority
 
 EXAMPLE
   $ gateway add-gatekeeper tgky5YfBseCvqehzsycwCG6rh2udA4w14MxZMnZz9Hp
 ```
 
-_See code: [dist/commands/add-gatekeeper.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v3.1.1-beta1/dist/commands/add-gatekeeper.ts)_
+_See code: [dist/commands/add-gatekeeper.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v3.1.1/dist/commands/add-gatekeeper.ts)_
 
 ## `gateway freeze GATEWAYTOKEN`
 
@@ -87,12 +84,12 @@ OPTIONS
                                                    cluster to target: mainnet-beta, testnet, devnet, civicnet, localnet.
                                                    Alternatively, set the environment variable SOLANA_CLUSTER
 
-  -g, --gatekeeperKey=gatekeeperKey                [default: 'tgnuXXNMDLK8dy7Xm1TdeGyc95MDym4bvAQCwcW21Bf'] The private key file for the gatekeeper
+  -g, --gatekeeperKey=gatekeeperKey                [default: [object Object]] The private key file for the gatekeeper
                                                    authority
 
   -h, --help                                       show CLI help
 
-  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: 'tgnuXXNMDLK8dy7Xm1TdeGyc95MDym4bvAQCwcW21Bf'] The public key (in base 58) of the
+  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The public key (in base 58) of the
                                                    gatekeeper network that the gatekeeper belongs to.
 
 EXAMPLE
@@ -100,7 +97,7 @@ EXAMPLE
   Frozen
 ```
 
-_See code: [dist/commands/freeze.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v3.1.1-beta1/dist/commands/freeze.ts)_
+_See code: [dist/commands/freeze.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v3.1.1/dist/commands/freeze.ts)_
 
 ## `gateway help [COMMAND]`
 
@@ -137,19 +134,19 @@ OPTIONS
 
   -e, --expiry=expiry                              The expiry time in seconds for the gateway token (default none)
 
-  -g, --gatekeeperKey=gatekeeperKey                [default: 'tgnuXXNMDLK8dy7Xm1TdeGyc95MDym4bvAQCwcW21Bf'] The private key file for the gatekeeper
+  -g, --gatekeeperKey=gatekeeperKey                [default: [object Object]] The private key file for the gatekeeper
                                                    authority
 
   -h, --help                                       show CLI help
 
-  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: 'tgnuXXNMDLK8dy7Xm1TdeGyc95MDym4bvAQCwcW21Bf'] The public key (in base 58) of the
+  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The public key (in base 58) of the
                                                    gatekeeper network that the gatekeeper belongs to.
 
 EXAMPLE
   $ gateway issue EzZgkwaDrgycsiyGeCVRXXRcieE1fxhGMp829qwj5TMv2QJjjrzdPSrcZUuAH2KrEU61crWz49KnSLSzwjDUnLSV
 ```
 
-_See code: [dist/commands/issue.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v3.1.1-beta1/dist/commands/issue.ts)_
+_See code: [dist/commands/issue.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v3.1.1/dist/commands/issue.ts)_
 
 ## `gateway refresh GATEWAYTOKEN [EXPIRY]`
 
@@ -168,12 +165,12 @@ OPTIONS
                                                    cluster to target: mainnet-beta, testnet, devnet, civicnet, localnet.
                                                    Alternatively, set the environment variable SOLANA_CLUSTER
 
-  -g, --gatekeeperKey=gatekeeperKey                [default: 'tgnuXXNMDLK8dy7Xm1TdeGyc95MDym4bvAQCwcW21Bf'] The private key file for the gatekeeper
+  -g, --gatekeeperKey=gatekeeperKey                [default: [object Object]] The private key file for the gatekeeper
                                                    authority
 
   -h, --help                                       show CLI help
 
-  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: 'tgnuXXNMDLK8dy7Xm1TdeGyc95MDym4bvAQCwcW21Bf'] The public key (in base 58) of the
+  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The public key (in base 58) of the
                                                    gatekeeper network that the gatekeeper belongs to.
 
 EXAMPLE
@@ -181,7 +178,7 @@ EXAMPLE
   Refreshed
 ```
 
-_See code: [dist/commands/refresh.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v3.1.1-beta1/dist/commands/refresh.ts)_
+_See code: [dist/commands/refresh.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v3.1.1/dist/commands/refresh.ts)_
 
 ## `gateway revoke GATEWAYTOKEN`
 
@@ -199,12 +196,12 @@ OPTIONS
                                                    cluster to target: mainnet-beta, testnet, devnet, civicnet, localnet.
                                                    Alternatively, set the environment variable SOLANA_CLUSTER
 
-  -g, --gatekeeperKey=gatekeeperKey                [default: 'tgnuXXNMDLK8dy7Xm1TdeGyc95MDym4bvAQCwcW21Bf'] The private key file for the gatekeeper
+  -g, --gatekeeperKey=gatekeeperKey                [default: [object Object]] The private key file for the gatekeeper
                                                    authority
 
   -h, --help                                       show CLI help
 
-  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: 'tgnuXXNMDLK8dy7Xm1TdeGyc95MDym4bvAQCwcW21Bf'] The public key (in base 58) of the
+  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The public key (in base 58) of the
                                                    gatekeeper network that the gatekeeper belongs to.
 
 EXAMPLE
@@ -212,7 +209,7 @@ EXAMPLE
   Revoked
 ```
 
-_See code: [dist/commands/revoke.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v3.1.1-beta1/dist/commands/revoke.ts)_
+_See code: [dist/commands/revoke.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v3.1.1/dist/commands/revoke.ts)_
 
 ## `gateway revoke-gatekeeper ADDRESS`
 
@@ -230,19 +227,19 @@ OPTIONS
                                                    cluster to target: mainnet-beta, testnet, devnet, civicnet, localnet.
                                                    Alternatively, set the environment variable SOLANA_CLUSTER
 
-  -g, --gatekeeperKey=gatekeeperKey                [default: 'tgnuXXNMDLK8dy7Xm1TdeGyc95MDym4bvAQCwcW21Bf'] The private key file for the gatekeeper
+  -g, --gatekeeperKey=gatekeeperKey                [default: [object Object]] The private key file for the gatekeeper
                                                    authority
 
   -h, --help                                       show CLI help
 
-  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: 'tgnuXXNMDLK8dy7Xm1TdeGyc95MDym4bvAQCwcW21Bf'] The private key file for the gatekeeper
+  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The private key file for the gatekeeper
                                                    authority
 
 EXAMPLE
   $ gateway revoke-gatekeeper tgky5YfBseCvqehzsycwCG6rh2udA4w14MxZMnZz9Hp
 ```
 
-_See code: [dist/commands/revoke-gatekeeper.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v3.1.1-beta1/dist/commands/revoke-gatekeeper.ts)_
+_See code: [dist/commands/revoke-gatekeeper.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v3.1.1/dist/commands/revoke-gatekeeper.ts)_
 
 ## `gateway unfreeze GATEWAYTOKEN`
 
@@ -260,12 +257,12 @@ OPTIONS
                                                    cluster to target: mainnet-beta, testnet, devnet, civicnet, localnet.
                                                    Alternatively, set the environment variable SOLANA_CLUSTER
 
-  -g, --gatekeeperKey=gatekeeperKey                [default: 'tgnuXXNMDLK8dy7Xm1TdeGyc95MDym4bvAQCwcW21Bf'] The private key file for the gatekeeper
+  -g, --gatekeeperKey=gatekeeperKey                [default: [object Object]] The private key file for the gatekeeper
                                                    authority
 
   -h, --help                                       show CLI help
 
-  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: 'tgnuXXNMDLK8dy7Xm1TdeGyc95MDym4bvAQCwcW21Bf'] The public key (in base 58) of the
+  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The public key (in base 58) of the
                                                    gatekeeper network that the gatekeeper belongs to.
 
 EXAMPLE
@@ -273,7 +270,7 @@ EXAMPLE
   Unfrozen
 ```
 
-_See code: [dist/commands/unfreeze.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v3.1.1-beta1/dist/commands/unfreeze.ts)_
+_See code: [dist/commands/unfreeze.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v3.1.1/dist/commands/unfreeze.ts)_
 
 ## `gateway verify OWNER`
 
@@ -293,7 +290,7 @@ OPTIONS
 
   -h, --help                                       show CLI help
 
-  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: 'tgnuXXNMDLK8dy7Xm1TdeGyc95MDym4bvAQCwcW21Bf'] The public key (in base 58) of the
+  -n, --gatekeeperNetworkKey=gatekeeperNetworkKey  [default: [object Object]] The public key (in base 58) of the
                                                    gatekeeper network that the gatekeeper belongs to.
 
 EXAMPLE
@@ -308,5 +305,5 @@ EXAMPLE
   }
 ```
 
-_See code: [dist/commands/verify.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v3.1.1-beta1/dist/commands/verify.ts)_
+_See code: [dist/commands/verify.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v3.1.1/dist/commands/verify.ts)_
 <!-- commandsstop -->

--- a/solana/gatekeeper-lib/docs/classes/GatekeeperNetworkService.html
+++ b/solana/gatekeeper-lib/docs/classes/GatekeeperNetworkService.html
@@ -112,7 +112,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/620082c/solana/gatekeeper-lib/src/service/GatekeeperNetworkService.ts#L25">service/GatekeeperNetworkService.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gatekeeper-lib/src/service/GatekeeperNetworkService.ts#L25">service/GatekeeperNetworkService.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -164,7 +164,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/620082c/solana/gatekeeper-lib/src/service/GatekeeperNetworkService.ts#L36">service/GatekeeperNetworkService.ts:36</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gatekeeper-lib/src/service/GatekeeperNetworkService.ts#L36">service/GatekeeperNetworkService.ts:36</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -197,7 +197,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/620082c/solana/gatekeeper-lib/src/service/GatekeeperNetworkService.ts#L98">service/GatekeeperNetworkService.ts:98</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gatekeeper-lib/src/service/GatekeeperNetworkService.ts#L98">service/GatekeeperNetworkService.ts:98</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/solana/gatekeeper-lib/docs/classes/GatekeeperService.html
+++ b/solana/gatekeeper-lib/docs/classes/GatekeeperService.html
@@ -121,7 +121,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/620082c/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L49">service/GatekeeperService.ts:49</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L49">service/GatekeeperService.ts:49</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -189,12 +189,12 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/620082c/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L110">service/GatekeeperService.ts:110</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L109">service/GatekeeperService.ts:109</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
-									<p>Builds and serializes a transaction with a token issuance instruction for sending later.</p>
+									<p>Builds, signs and serializes a transaction with a token issuance instruction for sending later.</p>
 								</div>
 							</div>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -220,13 +220,13 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/620082c/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L288">service/GatekeeperService.ts:288</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L287">service/GatekeeperService.ts:287</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
 									<p>Create a transaction with an update expiry instruction and return
-									a serialized form of the transaction with a dummy blockhash</p>
+									a serialized form of the transaction</p>
 								</div>
 							</div>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -252,7 +252,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/620082c/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L275">service/GatekeeperService.ts:275</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L274">service/GatekeeperService.ts:274</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -282,7 +282,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/620082c/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L242">service/GatekeeperService.ts:242</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L241">service/GatekeeperService.ts:241</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -315,7 +315,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/620082c/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L179">service/GatekeeperService.ts:179</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L178">service/GatekeeperService.ts:178</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -348,7 +348,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/620082c/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L218">service/GatekeeperService.ts:218</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L217">service/GatekeeperService.ts:217</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -375,13 +375,13 @@
 					<a name="sendSerializedTransaction" class="tsd-anchor"></a>
 					<h3>send<wbr>Serialized<wbr>Transaction</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">send<wbr>Serialized<wbr>Transaction<span class="tsd-signature-symbol">(</span>serializedTx<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, gatewayTokenKey<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">PublicKey</span>, sendOptions<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">SendOptions</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">DataTransaction</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">GatewayToken</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">send<wbr>Serialized<wbr>Transaction<span class="tsd-signature-symbol">(</span>serializedTx<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, gatewayTokenKey<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">PublicKey</span>, sendOptions<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">SendOptions</span>, recentBlockhash<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">DataTransaction</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">GatewayToken</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/620082c/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L350">service/GatekeeperService.ts:350</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L348">service/GatekeeperService.ts:348</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -389,9 +389,8 @@
 									<p>Given a serialized, unsigned transaction:</p>
 									<ul>
 										<li>hydrate the transaction</li>
-										<li>add a recent blockhash to increase change of success</li>
 										<li>check that the transaction is a gateway transaction</li>
-										<li>sign transaction with payer and gatekeeper authority</li>
+										<li>set the recentBlockhash on the transaction if provided in sendOptions</li>
 										<li>send the transaction to the chain</li>
 										<li>get the updated associated gateway token</li>
 									</ul>
@@ -408,6 +407,9 @@
 								<li>
 									<h5>sendOptions: <span class="tsd-signature-type">SendOptions</span><span class="tsd-signature-symbol"> = {}</span></h5>
 								</li>
+								<li>
+									<h5><span class="tsd-flag ts-flagOptional">Optional</span> recentBlockhash: <span class="tsd-signature-type">string</span></h5>
+								</li>
 							</ul>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">DataTransaction</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">GatewayToken</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span></h4>
 						</li>
@@ -417,13 +419,13 @@
 					<a name="signAndSerializeBuiltTransaction" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagPrivate">Private</span> sign<wbr>And<wbr>Serialize<wbr>Built<wbr>Transaction</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-private">
-						<li class="tsd-signature tsd-kind-icon">sign<wbr>And<wbr>Serialize<wbr>Built<wbr>Transaction<span class="tsd-signature-symbol">(</span>transaction<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Transaction</span>, blockhash<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">sign<wbr>And<wbr>Serialize<wbr>Built<wbr>Transaction<span class="tsd-signature-symbol">(</span>transaction<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Transaction</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/620082c/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L90">service/GatekeeperService.ts:90</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L90">service/GatekeeperService.ts:90</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -436,9 +438,6 @@
 							<ul class="tsd-parameters">
 								<li>
 									<h5>transaction: <span class="tsd-signature-type">Transaction</span></h5>
-								</li>
-								<li>
-									<h5><span class="tsd-flag ts-flagOptional">Optional</span> blockhash: <span class="tsd-signature-type">string</span></h5>
 								</li>
 							</ul>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -455,7 +454,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/620082c/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L259">service/GatekeeperService.ts:259</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L258">service/GatekeeperService.ts:258</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -488,7 +487,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/620082c/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L310">service/GatekeeperService.ts:310</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L309">service/GatekeeperService.ts:309</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -524,7 +523,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/620082c/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L193">service/GatekeeperService.ts:193</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gatekeeper-lib/src/service/GatekeeperService.ts#L192">service/GatekeeperService.ts:192</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/solana/gatekeeper-lib/package.json
+++ b/solana/gatekeeper-lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@identity.com/solana-gatekeeper-lib",
   "description": "Library and CLI to manage Gateway Tokens",
-  "version": "3.1.1-beta1",
+  "version": "3.1.1",
   "author": "dankelleher @dankelleher",
   "bin": {
     "gateway": "./bin/run"

--- a/solana/gatekeeper-lib/src/util/connection.ts
+++ b/solana/gatekeeper-lib/src/util/connection.ts
@@ -41,7 +41,6 @@ export const send = async (
   new SentTransaction(
     connection,
     await connection.sendTransaction(transaction, signers, {
-      preflightCommitment: SOLANA_COMMITMENT,
       ...options,
     })
   );

--- a/solana/gateway-ts/docs/classes/Active.html
+++ b/solana/gateway-ts/docs/classes/Active.html
@@ -111,7 +111,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Assignable.constructor</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/solanaBorsh.ts#L7">lib/solanaBorsh.ts:7</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/solanaBorsh.ts#L7">lib/solanaBorsh.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -143,7 +143,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Assignable.encode</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/solanaBorsh.ts#L16">lib/solanaBorsh.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/solanaBorsh.ts#L16">lib/solanaBorsh.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Buffer</span></h4>
@@ -161,7 +161,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Assignable.decode</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/solanaBorsh.ts#L20">lib/solanaBorsh.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/solanaBorsh.ts#L20">lib/solanaBorsh.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>

--- a/solana/gateway-ts/docs/classes/Frozen.html
+++ b/solana/gateway-ts/docs/classes/Frozen.html
@@ -111,7 +111,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Assignable.constructor</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/solanaBorsh.ts#L7">lib/solanaBorsh.ts:7</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/solanaBorsh.ts#L7">lib/solanaBorsh.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -143,7 +143,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Assignable.encode</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/solanaBorsh.ts#L16">lib/solanaBorsh.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/solanaBorsh.ts#L16">lib/solanaBorsh.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Buffer</span></h4>
@@ -161,7 +161,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Assignable.decode</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/solanaBorsh.ts#L20">lib/solanaBorsh.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/solanaBorsh.ts#L20">lib/solanaBorsh.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>

--- a/solana/gateway-ts/docs/classes/GatewayInstruction.html
+++ b/solana/gateway-ts/docs/classes/GatewayInstruction.html
@@ -129,7 +129,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Enum.constructor</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/solanaBorsh.ts#L30">lib/solanaBorsh.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/solanaBorsh.ts#L30">lib/solanaBorsh.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -151,7 +151,7 @@
 					<div class="tsd-signature tsd-kind-icon">add<wbr>Gatekeeper<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">AddGatekeeper</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/instruction.ts#L32">lib/instruction.ts:32</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/instruction.ts#L32">lib/instruction.ts:32</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -162,7 +162,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Enum.enum</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/solanaBorsh.ts#L28">lib/solanaBorsh.ts:28</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/solanaBorsh.ts#L28">lib/solanaBorsh.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -172,7 +172,7 @@
 					<div class="tsd-signature tsd-kind-icon">issue<wbr>Vanilla<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">IssueVanilla</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/instruction.ts#L33">lib/instruction.ts:33</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/instruction.ts#L33">lib/instruction.ts:33</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -182,7 +182,7 @@
 					<div class="tsd-signature tsd-kind-icon">revoke<wbr>Gatekeeper<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RevokeGatekeeper</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/instruction.ts#L36">lib/instruction.ts:36</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/instruction.ts#L36">lib/instruction.ts:36</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -192,7 +192,7 @@
 					<div class="tsd-signature tsd-kind-icon">set<wbr>State<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">SetState</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/instruction.ts#L34">lib/instruction.ts:34</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/instruction.ts#L34">lib/instruction.ts:34</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -202,7 +202,7 @@
 					<div class="tsd-signature tsd-kind-icon">update<wbr>Expiry<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">UpdateExpiry</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/instruction.ts#L35">lib/instruction.ts:35</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/instruction.ts#L35">lib/instruction.ts:35</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -220,7 +220,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Enum.encode</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/solanaBorsh.ts#L16">lib/solanaBorsh.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/solanaBorsh.ts#L16">lib/solanaBorsh.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Buffer</span></h4>
@@ -237,7 +237,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/instruction.ts#L38">lib/instruction.ts:38</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/instruction.ts#L38">lib/instruction.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="GatewayInstruction.html" class="tsd-signature-type" data-tsd-kind="Class">GatewayInstruction</a></h4>
@@ -255,7 +255,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Enum.decode</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/solanaBorsh.ts#L20">lib/solanaBorsh.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/solanaBorsh.ts#L20">lib/solanaBorsh.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -284,7 +284,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/instruction.ts#L61">lib/instruction.ts:61</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/instruction.ts#L61">lib/instruction.ts:61</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="GatewayInstruction.html" class="tsd-signature-type" data-tsd-kind="Class">GatewayInstruction</a></h4>
@@ -301,7 +301,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/instruction.ts#L44">lib/instruction.ts:44</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/instruction.ts#L44">lib/instruction.ts:44</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -327,7 +327,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/instruction.ts#L53">lib/instruction.ts:53</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/instruction.ts#L53">lib/instruction.ts:53</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="GatewayInstruction.html" class="tsd-signature-type" data-tsd-kind="Class">GatewayInstruction</a></h4>
@@ -344,7 +344,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/instruction.ts#L85">lib/instruction.ts:85</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/instruction.ts#L85">lib/instruction.ts:85</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="GatewayInstruction.html" class="tsd-signature-type" data-tsd-kind="Class">GatewayInstruction</a></h4>
@@ -361,7 +361,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/instruction.ts#L69">lib/instruction.ts:69</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/instruction.ts#L69">lib/instruction.ts:69</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="GatewayInstruction.html" class="tsd-signature-type" data-tsd-kind="Class">GatewayInstruction</a></h4>
@@ -378,7 +378,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/instruction.ts#L77">lib/instruction.ts:77</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/instruction.ts#L77">lib/instruction.ts:77</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/solana/gateway-ts/docs/classes/GatewayToken.html
+++ b/solana/gateway-ts/docs/classes/GatewayToken.html
@@ -119,7 +119,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/types/index.ts#L15">types/index.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/types/index.ts#L15">types/index.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -215,7 +215,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/types/index.ts#L30">types/index.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/types/index.ts#L30">types/index.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -232,7 +232,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/types/index.ts#L26">types/index.ts:26</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/types/index.ts#L26">types/index.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -249,7 +249,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/types/index.ts#L43">types/index.ts:43</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/types/index.ts#L43">types/index.ts:43</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -280,7 +280,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/types/index.ts#L35">types/index.ts:35</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/types/index.ts#L35">types/index.ts:35</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/solana/gateway-ts/docs/classes/GatewayTokenData.html
+++ b/solana/gateway-ts/docs/classes/GatewayTokenData.html
@@ -136,7 +136,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Assignable.constructor</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/solanaBorsh.ts#L7">lib/solanaBorsh.ts:7</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/solanaBorsh.ts#L7">lib/solanaBorsh.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -163,7 +163,7 @@
 					<div class="tsd-signature tsd-kind-icon">expiry<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">BN</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/GatewayTokenData.ts#L21">lib/GatewayTokenData.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/GatewayTokenData.ts#L21">lib/GatewayTokenData.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 					<div class="tsd-signature tsd-kind-icon">gatekeeper<wbr>Network<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">AssignablePublicKey</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/GatewayTokenData.ts#L19">lib/GatewayTokenData.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/GatewayTokenData.ts#L19">lib/GatewayTokenData.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -183,7 +183,7 @@
 					<div class="tsd-signature tsd-kind-icon">issuing<wbr>Gatekeeper<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">AssignablePublicKey</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/GatewayTokenData.ts#L18">lib/GatewayTokenData.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/GatewayTokenData.ts#L18">lib/GatewayTokenData.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -193,7 +193,7 @@
 					<div class="tsd-signature tsd-kind-icon">owner<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">AssignablePublicKey</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/GatewayTokenData.ts#L17">lib/GatewayTokenData.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/GatewayTokenData.ts#L17">lib/GatewayTokenData.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -203,7 +203,7 @@
 					<div class="tsd-signature tsd-kind-icon">state<span class="tsd-signature-symbol">:</span> <a href="GatewayTokenState.html" class="tsd-signature-type" data-tsd-kind="Class">GatewayTokenState</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/GatewayTokenData.ts#L20">lib/GatewayTokenData.ts:20</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/GatewayTokenData.ts#L20">lib/GatewayTokenData.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -221,7 +221,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Assignable.encode</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/solanaBorsh.ts#L16">lib/solanaBorsh.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/solanaBorsh.ts#L16">lib/solanaBorsh.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Buffer</span></h4>
@@ -238,7 +238,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/GatewayTokenData.ts#L27">lib/GatewayTokenData.ts:27</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/GatewayTokenData.ts#L27">lib/GatewayTokenData.ts:27</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -262,7 +262,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Assignable.decode</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/solanaBorsh.ts#L20">lib/solanaBorsh.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/solanaBorsh.ts#L20">lib/solanaBorsh.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -291,7 +291,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/GatewayTokenData.ts#L34">lib/GatewayTokenData.ts:34</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/GatewayTokenData.ts#L34">lib/GatewayTokenData.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -314,7 +314,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/GatewayTokenData.ts#L23">lib/GatewayTokenData.ts:23</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/GatewayTokenData.ts#L23">lib/GatewayTokenData.ts:23</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/solana/gateway-ts/docs/classes/GatewayTokenState.html
+++ b/solana/gateway-ts/docs/classes/GatewayTokenState.html
@@ -120,7 +120,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Enum.constructor</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/solanaBorsh.ts#L30">lib/solanaBorsh.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/solanaBorsh.ts#L30">lib/solanaBorsh.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">active<span class="tsd-signature-symbol">:</span> <a href="Active.html" class="tsd-signature-type" data-tsd-kind="Class">Active</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/GatewayTokenData.ts#L47">lib/GatewayTokenData.ts:47</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/GatewayTokenData.ts#L47">lib/GatewayTokenData.ts:47</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -153,7 +153,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Enum.enum</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/solanaBorsh.ts#L28">lib/solanaBorsh.ts:28</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/solanaBorsh.ts#L28">lib/solanaBorsh.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -163,7 +163,7 @@
 					<div class="tsd-signature tsd-kind-icon">frozen<span class="tsd-signature-symbol">:</span> <a href="Frozen.html" class="tsd-signature-type" data-tsd-kind="Class">Frozen</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/GatewayTokenData.ts#L48">lib/GatewayTokenData.ts:48</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/GatewayTokenData.ts#L48">lib/GatewayTokenData.ts:48</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 					<div class="tsd-signature tsd-kind-icon">revoked<span class="tsd-signature-symbol">:</span> <a href="Revoked.html" class="tsd-signature-type" data-tsd-kind="Class">Revoked</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/GatewayTokenData.ts#L49">lib/GatewayTokenData.ts:49</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/GatewayTokenData.ts#L49">lib/GatewayTokenData.ts:49</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -191,7 +191,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Enum.encode</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/solanaBorsh.ts#L16">lib/solanaBorsh.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/solanaBorsh.ts#L16">lib/solanaBorsh.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Buffer</span></h4>
@@ -209,7 +209,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Enum.decode</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/solanaBorsh.ts#L20">lib/solanaBorsh.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/solanaBorsh.ts#L20">lib/solanaBorsh.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>

--- a/solana/gateway-ts/docs/classes/Revoked.html
+++ b/solana/gateway-ts/docs/classes/Revoked.html
@@ -111,7 +111,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Assignable.constructor</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/solanaBorsh.ts#L7">lib/solanaBorsh.ts:7</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/solanaBorsh.ts#L7">lib/solanaBorsh.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -143,7 +143,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Assignable.encode</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/solanaBorsh.ts#L16">lib/solanaBorsh.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/solanaBorsh.ts#L16">lib/solanaBorsh.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Buffer</span></h4>
@@ -161,7 +161,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Assignable.decode</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/solanaBorsh.ts#L20">lib/solanaBorsh.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/solanaBorsh.ts#L20">lib/solanaBorsh.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>

--- a/solana/gateway-ts/docs/enums/State.html
+++ b/solana/gateway-ts/docs/enums/State.html
@@ -88,7 +88,7 @@
 					<div class="tsd-signature tsd-kind-icon">ACTIVE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;ACTIVE&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/types/index.ts#L10">types/index.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/types/index.ts#L10">types/index.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -98,7 +98,7 @@
 					<div class="tsd-signature tsd-kind-icon">FROZEN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;FROZEN&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/types/index.ts#L12">types/index.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/types/index.ts#L12">types/index.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -108,7 +108,7 @@
 					<div class="tsd-signature tsd-kind-icon">REVOKED<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;REVOKED&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/types/index.ts#L11">types/index.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/types/index.ts#L11">types/index.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/solana/gateway-ts/docs/index.html
+++ b/solana/gateway-ts/docs/index.html
@@ -131,7 +131,7 @@
 					<div class="tsd-signature tsd-kind-icon">Deep<wbr>Partial&lt;T&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{</span><span class="tsd-signature-symbol">[ </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol"> in </span><span class="tsd-signature-symbol">keyof </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">: </span><a href="index.html#DeepPartial" class="tsd-signature-type" data-tsd-kind="Type alias">DeepPartial</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/types/index.ts#L5">types/index.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/types/index.ts#L5">types/index.ts:5</a></li>
 						</ul>
 					</aside>
 					<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -147,7 +147,7 @@
 					<div class="tsd-signature tsd-kind-icon">Program<wbr>Account<wbr>Response<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>account<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">AccountInfo</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Buffer</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">; </span>pubkey<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">PublicKey</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/types/index.ts#L62">types/index.ts:62</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/types/index.ts#L62">types/index.ts:62</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -171,7 +171,7 @@
 					<div class="tsd-signature tsd-kind-icon">DEFAULT_<wbr>SOLANA_<wbr>RETRIES<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 3</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/constants.ts#L11">lib/constants.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/constants.ts#L11">lib/constants.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -181,7 +181,7 @@
 					<div class="tsd-signature tsd-kind-icon">GATEKEEPER_<wbr>NONCE_<wbr>SEED_<wbr>STRING<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">&quot;gatekeeper&quot;</span><span class="tsd-signature-symbol"> = &quot;gatekeeper&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/constants.ts#L7">lib/constants.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/constants.ts#L7">lib/constants.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -191,7 +191,7 @@
 					<div class="tsd-signature tsd-kind-icon">GATEWAY_<wbr>TOKEN_<wbr>ADDRESS_<wbr>SEED<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">&quot;gateway&quot;</span><span class="tsd-signature-symbol"> = &quot;gateway&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/constants.ts#L8">lib/constants.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/constants.ts#L8">lib/constants.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -201,7 +201,7 @@
 					<div class="tsd-signature tsd-kind-icon">PROGRAM_<wbr>ID<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">PublicKey</span><span class="tsd-signature-symbol"> = ...</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/constants.ts#L4">lib/constants.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/constants.ts#L4">lib/constants.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -211,7 +211,7 @@
 					<div class="tsd-signature tsd-kind-icon">SOLANA_<wbr>COMMITMENT<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Commitment</span><span class="tsd-signature-symbol"> = &quot;confirmed&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/constants.ts#L10">lib/constants.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/constants.ts#L10">lib/constants.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -221,7 +221,7 @@
 					<div class="tsd-signature tsd-kind-icon">SOLANA_<wbr>TIMEOUT_<wbr>CONFIRMED<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">7000</span><span class="tsd-signature-symbol"> = 7000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/constants.ts#L14">lib/constants.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/constants.ts#L14">lib/constants.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -231,7 +231,7 @@
 					<div class="tsd-signature tsd-kind-icon">SOLANA_<wbr>TIMEOUT_<wbr>FINALIZED<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">10000</span><span class="tsd-signature-symbol"> = 10000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/constants.ts#L15">lib/constants.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/constants.ts#L15">lib/constants.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -241,7 +241,7 @@
 					<div class="tsd-signature tsd-kind-icon">SOLANA_<wbr>TIMEOUT_<wbr>PROCESSED<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">3000</span><span class="tsd-signature-symbol"> = 3000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/constants.ts#L13">lib/constants.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/constants.ts#L13">lib/constants.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -258,7 +258,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/instruction.ts#L101">lib/instruction.ts:101</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/instruction.ts#L101">lib/instruction.ts:101</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -308,7 +308,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/util.ts#L85">lib/util.ts:85</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/util.ts#L85">lib/util.ts:85</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -334,7 +334,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/util.ts#L156">lib/util.ts:156</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/util.ts#L156">lib/util.ts:156</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -378,7 +378,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/util.ts#L111">lib/util.ts:111</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/util.ts#L111">lib/util.ts:111</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -430,7 +430,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/instruction.ts#L235">lib/instruction.ts:235</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/instruction.ts#L235">lib/instruction.ts:235</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -474,7 +474,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/util.ts#L245">lib/util.ts:245</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/util.ts#L245">lib/util.ts:245</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -517,7 +517,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/util.ts#L22">lib/util.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/util.ts#L22">lib/util.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -554,7 +554,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/util.ts#L222">lib/util.ts:222</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/util.ts#L222">lib/util.ts:222</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -591,7 +591,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/util.ts#L43">lib/util.ts:43</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/util.ts#L43">lib/util.ts:43</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -634,7 +634,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/instruction.ts#L165">lib/instruction.ts:165</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/instruction.ts#L165">lib/instruction.ts:165</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -709,7 +709,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/util.ts#L187">lib/util.ts:187</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/util.ts#L187">lib/util.ts:187</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -777,7 +777,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/util.ts#L212">lib/util.ts:212</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/util.ts#L212">lib/util.ts:212</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -814,7 +814,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/instruction.ts#L210">lib/instruction.ts:210</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/instruction.ts#L210">lib/instruction.ts:210</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -858,7 +858,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/instruction.ts#L132">lib/instruction.ts:132</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/instruction.ts#L132">lib/instruction.ts:132</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -908,7 +908,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/instruction.ts#L260">lib/instruction.ts:260</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/instruction.ts#L260">lib/instruction.ts:260</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -952,7 +952,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/b93384f/solana/gateway-ts/src/lib/instruction.ts#L286">lib/instruction.ts:286</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/0121f05/solana/gateway-ts/src/lib/instruction.ts#L286">lib/instruction.ts:286</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/solana/yarn.lock
+++ b/solana/yarn.lock
@@ -261,17 +261,6 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@identity.com/solana-gateway-ts@^0.8.1":
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/@identity.com/solana-gateway-ts/-/solana-gateway-ts-0.8.1.tgz#387facc495b2256ce2e3ec1673f9e8a09180b52e"
-  integrity sha512-Ezy2rwBfRpfzVyoqiW34AkczR0YxVLN7+kuFvofT/cyMVGpB/4a+lBjPQT6UHXKX9jkP6vyiSsV+VX6jnoimkg==
-  dependencies:
-    "@solana/web3.js" "^1.22.0"
-    async-retry "^1.3.3"
-    bn.js "^5.2.0"
-    borsh "^0.4.0"
-    ramda "^0.27.1"
-
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"


### PR DESCRIPTION
 Remove preflightCommitment from sent tx'es, as it may clash with the recentBlockhash commitment of 'finalized' used inside web3, possibly leading to "Blockhash not found" errors.

Published 3.1.1 to npm.