### PR TITLE
fix: fixing oracle null verification

### DIFF
--- a/ethereum/gateway-eth-ts/src/utils/gas.ts
+++ b/ethereum/gateway-eth-ts/src/utils/gas.ts
@@ -63,7 +63,7 @@ export const currentGasPrices = async (
   oracle?: GasPriceOracle,
   fallbackGasPrices?: GasPrices
 ): Promise<GasPrices> => {
-  if (oracle === null) {
+  if (!oracle) {
     oracle = new GasPriceOracle(options);
   }
 


### PR DESCRIPTION
In `Gas@currentGasPrices` it checks for `oracle === null` but if it's defined, it will throw an error.