### PR TITLE
CIV-4725 Add rinkeby addresses

### DIFF
--- a/ethereum/gateway-eth-ts/README.md
+++ b/ethereum/gateway-eth-ts/README.md
@@ -75,41 +75,38 @@ The easiest way to associate certain flags with the identity token is by using l
 ## Usage
 
 <!-- usage -->
-
 ```sh-session
 $ npm install -g @identity.com/gateway-eth-ts
 $ gateway-eth-ts COMMAND
 running command...
 $ gateway-eth-ts (-v|--version|version)
-@identity.com/gateway-eth-ts/0.1.2 darwin-x64 node-v14.18.2
+@identity.com/gateway-eth-ts/0.1.2-beta8 darwin-x64 node-v14.19.1
 $ gateway-eth-ts --help [COMMAND]
 USAGE
   $ gateway-eth-ts COMMAND
 ...
 ```
-
 <!-- usagestop -->
 
 ## Commands
 
 <!-- commands -->
-
-- [`gateway-eth-ts add-gatekeeper ADDRESS`](#gateway-eth-ts-add-gatekeeper-address)
-- [`gateway-eth-ts add-network-authority ADDRESS`](#gateway-eth-ts-add-network-authority-address)
-- [`gateway-eth-ts blacklist ADDRESS`](#gateway-eth-ts-blacklist-address)
-- [`gateway-eth-ts burn TOKENID`](#gateway-eth-ts-burn-tokenid)
-- [`gateway-eth-ts freeze TOKENID`](#gateway-eth-ts-freeze-tokenid)
-- [`gateway-eth-ts get-token TOKENID`](#gateway-eth-ts-get-token-tokenid)
-- [`gateway-eth-ts get-token-id ADDRESS`](#gateway-eth-ts-get-token-id-address)
-- [`gateway-eth-ts help [COMMAND]`](#gateway-eth-ts-help-command)
-- [`gateway-eth-ts issue ADDRESS [EXPIRATION] [CONSTRAINS]`](#gateway-eth-ts-issue-address-expiration-constrains)
-- [`gateway-eth-ts refresh TOKENID [EXPIRY]`](#gateway-eth-ts-refresh-tokenid-expiry)
-- [`gateway-eth-ts remove-gatekeeper ADDRESS`](#gateway-eth-ts-remove-gatekeeper-address)
-- [`gateway-eth-ts remove-network-authority ADDRESS`](#gateway-eth-ts-remove-network-authority-address)
-- [`gateway-eth-ts revoke TOKENID`](#gateway-eth-ts-revoke-tokenid)
-- [`gateway-eth-ts unfreeze TOKENID`](#gateway-eth-ts-unfreeze-tokenid)
-- [`gateway-eth-ts verify ADDRESS [TOKENID]`](#gateway-eth-ts-verify-address-tokenid)
-- [`gateway-eth-ts version`](#gateway-eth-ts-version)
+* [`gateway-eth-ts add-gatekeeper ADDRESS`](#gateway-eth-ts-add-gatekeeper-address)
+* [`gateway-eth-ts add-network-authority ADDRESS`](#gateway-eth-ts-add-network-authority-address)
+* [`gateway-eth-ts blacklist ADDRESS`](#gateway-eth-ts-blacklist-address)
+* [`gateway-eth-ts burn TOKENID`](#gateway-eth-ts-burn-tokenid)
+* [`gateway-eth-ts freeze TOKENID`](#gateway-eth-ts-freeze-tokenid)
+* [`gateway-eth-ts get-token TOKENID`](#gateway-eth-ts-get-token-tokenid)
+* [`gateway-eth-ts get-token-id ADDRESS`](#gateway-eth-ts-get-token-id-address)
+* [`gateway-eth-ts help [COMMAND]`](#gateway-eth-ts-help-command)
+* [`gateway-eth-ts issue ADDRESS [EXPIRATION] [CONSTRAINS]`](#gateway-eth-ts-issue-address-expiration-constrains)
+* [`gateway-eth-ts refresh TOKENID [EXPIRY]`](#gateway-eth-ts-refresh-tokenid-expiry)
+* [`gateway-eth-ts remove-gatekeeper ADDRESS`](#gateway-eth-ts-remove-gatekeeper-address)
+* [`gateway-eth-ts remove-network-authority ADDRESS`](#gateway-eth-ts-remove-network-authority-address)
+* [`gateway-eth-ts revoke TOKENID`](#gateway-eth-ts-revoke-tokenid)
+* [`gateway-eth-ts unfreeze TOKENID`](#gateway-eth-ts-unfreeze-tokenid)
+* [`gateway-eth-ts verify ADDRESS [TOKENID]`](#gateway-eth-ts-verify-address-tokenid)
+* [`gateway-eth-ts version`](#gateway-eth-ts-version)
 
 ## `gateway-eth-ts add-gatekeeper ADDRESS`
 
@@ -125,23 +122,23 @@ ARGUMENTS
 OPTIONS
   -c, --confirmations=confirmations              [default: 0] The amount of blocks to wait mined transaction
 
-  -f, --gasPriceFee=gasPriceFee                  [default: [object Object]] Gas Price level to execute transaction with.
-                                                 For example: instant, fast, standard, slow
+  -f, --gasPriceFee=gasPriceFee                  [default: [object Promise]] Gas Price level to execute transaction
+                                                 with. For example: instant, fast, standard, slow
 
   -h, --help                                     Show CLI help.
 
-  -n, --network=network                          [default: [object Object]] Specify target network to work with
+  -n, --network=network                          [default: [object Promise]] Specify target network to work with
 
-  -p, --privateKey=privateKey                    [default: [object Object]] The ethereum address private key for signing
-                                                 messages
+  -p, --privateKey=privateKey                    [default: [object Promise]] The ethereum address private key for
+                                                 signing messages
 
-  -t, --gatewayTokenAddress=gatewayTokenAddress  [default: [object Object]] GatewayToken address to target
+  -t, --gatewayTokenAddress=gatewayTokenAddress  [default: [object Promise]] GatewayToken address to target
 
 EXAMPLE
   $ gateway add-gatekeeper 0x893F4Be53274353CD3379C87C8fd1cb4f8458F94
 ```
 
-_See code: [dist/commands/add-gatekeeper.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v0.1.2/dist/commands/add-gatekeeper.ts)_
+_See code: [dist/commands/add-gatekeeper.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v0.1.2-beta8/dist/commands/add-gatekeeper.ts)_
 
 ## `gateway-eth-ts add-network-authority ADDRESS`
 
@@ -157,23 +154,23 @@ ARGUMENTS
 OPTIONS
   -c, --confirmations=confirmations              [default: 0] The amount of blocks to wait mined transaction
 
-  -f, --gasPriceFee=gasPriceFee                  [default: [object Object]] Gas Price level to execute transaction with.
-                                                 For example: instant, fast, standard, slow
+  -f, --gasPriceFee=gasPriceFee                  [default: [object Promise]] Gas Price level to execute transaction
+                                                 with. For example: instant, fast, standard, slow
 
   -h, --help                                     Show CLI help.
 
-  -n, --network=network                          [default: [object Object]] Specify target network to work with
+  -n, --network=network                          [default: [object Promise]] Specify target network to work with
 
-  -p, --privateKey=privateKey                    [default: [object Object]] The ethereum address private key for signing
-                                                 messages
+  -p, --privateKey=privateKey                    [default: [object Promise]] The ethereum address private key for
+                                                 signing messages
 
-  -t, --gatewayTokenAddress=gatewayTokenAddress  [default: [object Object]] GatewayToken address to target
+  -t, --gatewayTokenAddress=gatewayTokenAddress  [default: [object Promise]] GatewayToken address to target
 
 EXAMPLE
   $ gateway add-network-authority 0x893F4Be53274353CD3379C87C8fd1cb4f8458F94
 ```
 
-_See code: [dist/commands/add-network-authority.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v0.1.2/dist/commands/add-network-authority.ts)_
+_See code: [dist/commands/add-network-authority.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v0.1.2-beta8/dist/commands/add-network-authority.ts)_
 
 ## `gateway-eth-ts blacklist ADDRESS`
 
@@ -189,20 +186,20 @@ ARGUMENTS
 OPTIONS
   -c, --confirmations=confirmations  [default: 0] The amount of blocks to wait mined transaction
 
-  -f, --gasPriceFee=gasPriceFee      [default: [object Object]] Gas Price level to execute transaction with. For
+  -f, --gasPriceFee=gasPriceFee      [default: [object Promise]] Gas Price level to execute transaction with. For
                                      example: instant, fast, standard, slow
 
   -h, --help                         Show CLI help.
 
-  -n, --network=network              [default: [object Object]] Specify target network to work with
+  -n, --network=network              [default: [object Promise]] Specify target network to work with
 
-  -p, --privateKey=privateKey        [default: [object Object]] The ethereum address private key for signing messages
+  -p, --privateKey=privateKey        [default: [object Promise]] The ethereum address private key for signing messages
 
 EXAMPLE
   $ gateway blacklist 0x893F4Be53274353CD3379C87C8fd1cb4f8458F94
 ```
 
-_See code: [dist/commands/blacklist.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v0.1.2/dist/commands/blacklist.ts)_
+_See code: [dist/commands/blacklist.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v0.1.2-beta8/dist/commands/blacklist.ts)_
 
 ## `gateway-eth-ts burn TOKENID`
 
@@ -218,23 +215,23 @@ ARGUMENTS
 OPTIONS
   -c, --confirmations=confirmations              [default: 0] The amount of blocks to wait mined transaction
 
-  -f, --gasPriceFee=gasPriceFee                  [default: [object Object]] Gas Price level to execute transaction with.
-                                                 For example: instant, fast, standard, slow
+  -f, --gasPriceFee=gasPriceFee                  [default: [object Promise]] Gas Price level to execute transaction
+                                                 with. For example: instant, fast, standard, slow
 
   -h, --help                                     Show CLI help.
 
-  -n, --network=network                          [default: [object Object]] Specify target network to work with
+  -n, --network=network                          [default: [object Promise]] Specify target network to work with
 
-  -p, --privateKey=privateKey                    [default: [object Object]] The ethereum address private key for signing
-                                                 messages
+  -p, --privateKey=privateKey                    [default: [object Promise]] The ethereum address private key for
+                                                 signing messages
 
-  -t, --gatewayTokenAddress=gatewayTokenAddress  [default: [object Object]] GatewayToken address to target
+  -t, --gatewayTokenAddress=gatewayTokenAddress  [default: [object Promise]] GatewayToken address to target
 
 EXAMPLE
   $ gateway burn 10
 ```
 
-_See code: [dist/commands/burn.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v0.1.2/dist/commands/burn.ts)_
+_See code: [dist/commands/burn.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v0.1.2-beta8/dist/commands/burn.ts)_
 
 ## `gateway-eth-ts freeze TOKENID`
 
@@ -250,23 +247,23 @@ ARGUMENTS
 OPTIONS
   -c, --confirmations=confirmations              [default: 0] The amount of blocks to wait mined transaction
 
-  -f, --gasPriceFee=gasPriceFee                  [default: [object Object]] Gas Price level to execute transaction with.
-                                                 For example: instant, fast, standard, slow
+  -f, --gasPriceFee=gasPriceFee                  [default: [object Promise]] Gas Price level to execute transaction
+                                                 with. For example: instant, fast, standard, slow
 
   -h, --help                                     Show CLI help.
 
-  -n, --network=network                          [default: [object Object]] Specify target network to work with
+  -n, --network=network                          [default: [object Promise]] Specify target network to work with
 
-  -p, --privateKey=privateKey                    [default: [object Object]] The ethereum address private key for signing
-                                                 messages
+  -p, --privateKey=privateKey                    [default: [object Promise]] The ethereum address private key for
+                                                 signing messages
 
-  -t, --gatewayTokenAddress=gatewayTokenAddress  [default: [object Object]] GatewayToken address to target
+  -t, --gatewayTokenAddress=gatewayTokenAddress  [default: [object Promise]] GatewayToken address to target
 
 EXAMPLE
   $ gateway freeze 10
 ```
 
-_See code: [dist/commands/freeze.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v0.1.2/dist/commands/freeze.ts)_
+_See code: [dist/commands/freeze.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v0.1.2-beta8/dist/commands/freeze.ts)_
 
 ## `gateway-eth-ts get-token TOKENID`
 
@@ -281,18 +278,18 @@ ARGUMENTS
 
 OPTIONS
   -h, --help                                     Show CLI help.
-  -n, --network=network                          [default: [object Object]] Specify target network to work with
+  -n, --network=network                          [default: [object Promise]] Specify target network to work with
 
-  -p, --privateKey=privateKey                    [default: [object Object]] The ethereum address private key for signing
-                                                 messages
+  -p, --privateKey=privateKey                    [default: [object Promise]] The ethereum address private key for
+                                                 signing messages
 
-  -t, --gatewayTokenAddress=gatewayTokenAddress  [default: [object Object]] GatewayToken address to target
+  -t, --gatewayTokenAddress=gatewayTokenAddress  [default: [object Promise]] GatewayToken address to target
 
 EXAMPLE
   $ gateway get-token 10
 ```
 
-_See code: [dist/commands/get-token.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v0.1.2/dist/commands/get-token.ts)_
+_See code: [dist/commands/get-token.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v0.1.2-beta8/dist/commands/get-token.ts)_
 
 ## `gateway-eth-ts get-token-id ADDRESS`
 
@@ -307,18 +304,18 @@ ARGUMENTS
 
 OPTIONS
   -h, --help                                     Show CLI help.
-  -n, --network=network                          [default: [object Object]] Specify target network to work with
+  -n, --network=network                          [default: [object Promise]] Specify target network to work with
 
-  -p, --privateKey=privateKey                    [default: [object Object]] The ethereum address private key for signing
-                                                 messages
+  -p, --privateKey=privateKey                    [default: [object Promise]] The ethereum address private key for
+                                                 signing messages
 
-  -t, --gatewayTokenAddress=gatewayTokenAddress  [default: [object Object]] GatewayToken address to target
+  -t, --gatewayTokenAddress=gatewayTokenAddress  [default: [object Promise]] GatewayToken address to target
 
 EXAMPLE
   $ gateway get-token-id 0x893F4Be53274353CD3379C87C8fd1cb4f8458F94
 ```
 
-_See code: [dist/commands/get-token-id.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v0.1.2/dist/commands/get-token-id.ts)_
+_See code: [dist/commands/get-token-id.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v0.1.2-beta8/dist/commands/get-token-id.ts)_
 
 ## `gateway-eth-ts help [COMMAND]`
 
@@ -348,16 +345,14 @@ USAGE
 ARGUMENTS
   ADDRESS     Owner ethereum address to tokenID for
   EXPIRATION  [default: 0] Expiration timestamp for newly issued token
-  CONSTRAINS  [default: [object Object]] Constrains to generate tokenId
+  CONSTRAINS  [default: 0] Constrains to generate tokenId
 
 OPTIONS
-  -b, --bitmask=bitmask                          [default: [object Object]] Bitmask constrains to link with newly
-                                                 minting tokenID
-
+  -b, --bitmask=bitmask                          [default: 0] Bitmask constrains to link with newly minting tokenID
   -c, --confirmations=confirmations              [default: 0] The amount of blocks to wait mined transaction
 
-  -f, --gasPriceFee=gasPriceFee                  [default: [object Object]] Gas Price level to execute transaction with.
-                                                 For example: instant, fast, standard, slow
+  -f, --gasPriceFee=gasPriceFee                  [default: [object Promise]] Gas Price level to execute transaction
+                                                 with. For example: instant, fast, standard, slow
 
   -g, --[no-]generateTokenId                     Identifier used to determine wether tokenId has to be generated
 
@@ -365,12 +360,12 @@ OPTIONS
 
   -i, --tokenID=tokenID                          Token ID number to issue
 
-  -n, --network=network                          [default: [object Object]] Specify target network to work with
+  -n, --network=network                          [default: [object Promise]] Specify target network to work with
 
-  -p, --privateKey=privateKey                    [default: [object Object]] The ethereum address private key for signing
-                                                 messages
+  -p, --privateKey=privateKey                    [default: [object Promise]] The ethereum address private key for
+                                                 signing messages
 
-  -t, --gatewayTokenAddress=gatewayTokenAddress  [default: [object Object]] GatewayToken address to target
+  -t, --gatewayTokenAddress=gatewayTokenAddress  [default: [object Promise]] GatewayToken address to target
 
   --[no-]forwardTransaction                      Whether the transaction will be sent via the Forwarder contract
 
@@ -378,7 +373,7 @@ EXAMPLE
   $ gateway issue 0x893F4Be53274353CD3379C87C8fd1cb4f8458F94 -i <TokenID>
 ```
 
-_See code: [dist/commands/issue.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v0.1.2/dist/commands/issue.ts)_
+_See code: [dist/commands/issue.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v0.1.2-beta8/dist/commands/issue.ts)_
 
 ## `gateway-eth-ts refresh TOKENID [EXPIRY]`
 
@@ -395,23 +390,23 @@ ARGUMENTS
 OPTIONS
   -c, --confirmations=confirmations              [default: 0] The amount of blocks to wait mined transaction
 
-  -f, --gasPriceFee=gasPriceFee                  [default: [object Object]] Gas Price level to execute transaction with.
-                                                 For example: instant, fast, standard, slow
+  -f, --gasPriceFee=gasPriceFee                  [default: [object Promise]] Gas Price level to execute transaction
+                                                 with. For example: instant, fast, standard, slow
 
   -h, --help                                     Show CLI help.
 
-  -n, --network=network                          [default: [object Object]] Specify target network to work with
+  -n, --network=network                          [default: [object Promise]] Specify target network to work with
 
-  -p, --privateKey=privateKey                    [default: [object Object]] The ethereum address private key for signing
-                                                 messages
+  -p, --privateKey=privateKey                    [default: [object Promise]] The ethereum address private key for
+                                                 signing messages
 
-  -t, --gatewayTokenAddress=gatewayTokenAddress  [default: [object Object]] GatewayToken address to target
+  -t, --gatewayTokenAddress=gatewayTokenAddress  [default: [object Promise]] GatewayToken address to target
 
 EXAMPLE
   $ gateway refresh 10 0x893F4Be53274353CD3379C87C8fd1cb4f8458F94
 ```
 
-_See code: [dist/commands/refresh.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v0.1.2/dist/commands/refresh.ts)_
+_See code: [dist/commands/refresh.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v0.1.2-beta8/dist/commands/refresh.ts)_
 
 ## `gateway-eth-ts remove-gatekeeper ADDRESS`
 
@@ -427,23 +422,23 @@ ARGUMENTS
 OPTIONS
   -c, --confirmations=confirmations              [default: 0] The amount of blocks to wait mined transaction
 
-  -f, --gasPriceFee=gasPriceFee                  [default: [object Object]] Gas Price level to execute transaction with.
-                                                 For example: instant, fast, standard, slow
+  -f, --gasPriceFee=gasPriceFee                  [default: [object Promise]] Gas Price level to execute transaction
+                                                 with. For example: instant, fast, standard, slow
 
   -h, --help                                     Show CLI help.
 
-  -n, --network=network                          [default: [object Object]] Specify target network to work with
+  -n, --network=network                          [default: [object Promise]] Specify target network to work with
 
-  -p, --privateKey=privateKey                    [default: [object Object]] The ethereum address private key for signing
-                                                 messages
+  -p, --privateKey=privateKey                    [default: [object Promise]] The ethereum address private key for
+                                                 signing messages
 
-  -t, --gatewayTokenAddress=gatewayTokenAddress  [default: [object Object]] GatewayToken address to target
+  -t, --gatewayTokenAddress=gatewayTokenAddress  [default: [object Promise]] GatewayToken address to target
 
 EXAMPLE
   $ gateway remove-gatekeeper 0x893F4Be53274353CD3379C87C8fd1cb4f8458F94
 ```
 
-_See code: [dist/commands/remove-gatekeeper.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v0.1.2/dist/commands/remove-gatekeeper.ts)_
+_See code: [dist/commands/remove-gatekeeper.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v0.1.2-beta8/dist/commands/remove-gatekeeper.ts)_
 
 ## `gateway-eth-ts remove-network-authority ADDRESS`
 
@@ -459,23 +454,23 @@ ARGUMENTS
 OPTIONS
   -c, --confirmations=confirmations              [default: 0] The amount of blocks to wait mined transaction
 
-  -f, --gasPriceFee=gasPriceFee                  [default: [object Object]] Gas Price level to execute transaction with.
-                                                 For example: instant, fast, standard, slow
+  -f, --gasPriceFee=gasPriceFee                  [default: [object Promise]] Gas Price level to execute transaction
+                                                 with. For example: instant, fast, standard, slow
 
   -h, --help                                     Show CLI help.
 
-  -n, --network=network                          [default: [object Object]] Specify target network to work with
+  -n, --network=network                          [default: [object Promise]] Specify target network to work with
 
-  -p, --privateKey=privateKey                    [default: [object Object]] The ethereum address private key for signing
-                                                 messages
+  -p, --privateKey=privateKey                    [default: [object Promise]] The ethereum address private key for
+                                                 signing messages
 
-  -t, --gatewayTokenAddress=gatewayTokenAddress  [default: [object Object]] GatewayToken address to target
+  -t, --gatewayTokenAddress=gatewayTokenAddress  [default: [object Promise]] GatewayToken address to target
 
 EXAMPLE
   $ gateway remove-network-authority 0x893F4Be53274353CD3379C87C8fd1cb4f8458F94
 ```
 
-_See code: [dist/commands/remove-network-authority.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v0.1.2/dist/commands/remove-network-authority.ts)_
+_See code: [dist/commands/remove-network-authority.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v0.1.2-beta8/dist/commands/remove-network-authority.ts)_
 
 ## `gateway-eth-ts revoke TOKENID`
 
@@ -491,23 +486,23 @@ ARGUMENTS
 OPTIONS
   -c, --confirmations=confirmations              [default: 0] The amount of blocks to wait mined transaction
 
-  -f, --gasPriceFee=gasPriceFee                  [default: [object Object]] Gas Price level to execute transaction with.
-                                                 For example: instant, fast, standard, slow
+  -f, --gasPriceFee=gasPriceFee                  [default: [object Promise]] Gas Price level to execute transaction
+                                                 with. For example: instant, fast, standard, slow
 
   -h, --help                                     Show CLI help.
 
-  -n, --network=network                          [default: [object Object]] Specify target network to work with
+  -n, --network=network                          [default: [object Promise]] Specify target network to work with
 
-  -p, --privateKey=privateKey                    [default: [object Object]] The ethereum address private key for signing
-                                                 messages
+  -p, --privateKey=privateKey                    [default: [object Promise]] The ethereum address private key for
+                                                 signing messages
 
-  -t, --gatewayTokenAddress=gatewayTokenAddress  [default: [object Object]] GatewayToken address to target
+  -t, --gatewayTokenAddress=gatewayTokenAddress  [default: [object Promise]] GatewayToken address to target
 
 EXAMPLE
   $ gateway revoke 10
 ```
 
-_See code: [dist/commands/revoke.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v0.1.2/dist/commands/revoke.ts)_
+_See code: [dist/commands/revoke.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v0.1.2-beta8/dist/commands/revoke.ts)_
 
 ## `gateway-eth-ts unfreeze TOKENID`
 
@@ -523,23 +518,23 @@ ARGUMENTS
 OPTIONS
   -c, --confirmations=confirmations              [default: 0] The amount of blocks to wait mined transaction
 
-  -f, --gasPriceFee=gasPriceFee                  [default: [object Object]] Gas Price level to execute transaction with.
-                                                 For example: instant, fast, standard, slow
+  -f, --gasPriceFee=gasPriceFee                  [default: [object Promise]] Gas Price level to execute transaction
+                                                 with. For example: instant, fast, standard, slow
 
   -h, --help                                     Show CLI help.
 
-  -n, --network=network                          [default: [object Object]] Specify target network to work with
+  -n, --network=network                          [default: [object Promise]] Specify target network to work with
 
-  -p, --privateKey=privateKey                    [default: [object Object]] The ethereum address private key for signing
-                                                 messages
+  -p, --privateKey=privateKey                    [default: [object Promise]] The ethereum address private key for
+                                                 signing messages
 
-  -t, --gatewayTokenAddress=gatewayTokenAddress  [default: [object Object]] GatewayToken address to target
+  -t, --gatewayTokenAddress=gatewayTokenAddress  [default: [object Promise]] GatewayToken address to target
 
 EXAMPLE
   $ gateway unfreeze 10
 ```
 
-_See code: [dist/commands/unfreeze.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v0.1.2/dist/commands/unfreeze.ts)_
+_See code: [dist/commands/unfreeze.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v0.1.2-beta8/dist/commands/unfreeze.ts)_
 
 ## `gateway-eth-ts verify ADDRESS [TOKENID]`
 
@@ -555,18 +550,18 @@ ARGUMENTS
 
 OPTIONS
   -h, --help                                     Show CLI help.
-  -n, --network=network                          [default: [object Object]] Specify target network to work with
+  -n, --network=network                          [default: [object Promise]] Specify target network to work with
 
-  -p, --privateKey=privateKey                    [default: [object Object]] The ethereum address private key for signing
-                                                 messages
+  -p, --privateKey=privateKey                    [default: [object Promise]] The ethereum address private key for
+                                                 signing messages
 
-  -t, --gatewayTokenAddress=gatewayTokenAddress  [default: [object Object]] GatewayToken address to target
+  -t, --gatewayTokenAddress=gatewayTokenAddress  [default: [object Promise]] GatewayToken address to target
 
 EXAMPLE
   $ gateway verify 0x893F4Be53274353CD3379C87C8fd1cb4f8458F94
 ```
 
-_See code: [dist/commands/verify.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v0.1.2/dist/commands/verify.ts)_
+_See code: [dist/commands/verify.ts](https://github.com/identity-com/on-chain-identity-gateway/blob/v0.1.2-beta8/dist/commands/verify.ts)_
 
 ## `gateway-eth-ts version`
 
@@ -576,7 +571,6 @@ USAGE
 ```
 
 _See code: [@oclif/plugin-version](https://github.com/oclif/plugin-version/blob/v1.0.4/src/commands/version.ts)_
-
 <!-- commandsstop -->
 
 - [`gateway-eth-ts add-gatekeeper ADDRESS`](#gateway-eth-ts-add-gatekeeper-address)

--- a/ethereum/gateway-eth-ts/package.json
+++ b/ethereum/gateway-eth-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/gateway-eth-ts",
-  "version": "0.1.2-beta7",
+  "version": "0.1.2-beta8",
   "description": "Adapter library for Identity.com gateway token system on Ethereum",
   "main": "dist/index.js",
   "scripts": {

--- a/ethereum/gateway-eth-ts/package.json
+++ b/ethereum/gateway-eth-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/gateway-eth-ts",
-  "version": "0.1.2",
+  "version": "0.1.2-beta7",
   "description": "Adapter library for Identity.com gateway token system on Ethereum",
   "main": "dist/index.js",
   "scripts": {

--- a/ethereum/gateway-eth-ts/src/GatewayTs.ts
+++ b/ethereum/gateway-eth-ts/src/GatewayTs.ts
@@ -1,5 +1,5 @@
 import { BigNumber, PopulatedTransaction, Signer } from "ethers";
-import { Network } from '@ethersproject/providers';
+import { Network, Provider } from '@ethersproject/providers';
 import { TypedDataSigner } from "@ethersproject/abstract-signer";
 
 import { ethTransaction, populateTx, TxOptions } from "./utils/tx";
@@ -12,12 +12,12 @@ import { signMetaTxRequest } from "./utils/signer";
 export class GatewayTs extends GatewayTsBase {
   // eslint-disable-next-line no-useless-constructor
   constructor(
-    signer: Signer,
+    providerOrSigner: Provider | Signer,
     network: Network,
     defaultGatewayToken?: string,
     options?: { defaultGas?: number; defaultGasPrice?: any }
   ) {
-    super(signer, network, defaultGatewayToken, options);
+    super(providerOrSigner, network, defaultGatewayToken, options);
   }
 
   async addGatekeeper(

--- a/ethereum/gateway-eth-ts/src/index.ts
+++ b/ethereum/gateway-eth-ts/src/index.ts
@@ -1,6 +1,6 @@
 import { GatewayTs } from "./GatewayTs";
 import { Signer, utils } from "ethers";
-import { Network } from "@ethersproject/providers";
+import { Network, Provider } from "@ethersproject/providers";
 export { GasPriceKey } from "./utils/gas";
 export { TokenData, SendableTransaction, SentTransaction } from "./utils/types";
 export { DEFAULT_GATEWAY_TOKEN } from "./utils/constants";
@@ -15,19 +15,19 @@ export class GatewayETH extends GatewayTs {
    * const {GatewayETH} = require('GatewayTS');
    * const gatewayTs = new GatewayETH();
    * @constructor
-   * @param signer {Ethers signer, gets default provider if there is no signer provided}
+   * @param providerOrSigner {Ethers signer or provider, gets default provider if not provided}
    * @param network {Ethers network class}
    * @param defaultGatewayToken {Address of default gateway token contract}
    * @param options {Gas, gasPrice}
    * @notice utils {Ethers utils}
    */
   constructor(
-    signer: Signer,
+    providerOrSigner: Provider | Signer,
     network: Network,
     defaultGatewayToken?: string,
     options?: { defaultGas?: number; defaultGasPrice?: any }
   ) {
-    super(signer, network, defaultGatewayToken, options);
+    super(providerOrSigner, network, defaultGatewayToken, options);
     this.utils = utils;
   }
 }

--- a/ethereum/gateway-eth-ts/src/lib/addresses.ts
+++ b/ethereum/gateway-eth-ts/src/lib/addresses.ts
@@ -16,6 +16,12 @@ const ROPSTEN_ADDRESSES: ContractAddresses = {
     forwarder: '0x79C2bDD404e629828E3702a5f2cdd01FD5De8808',
 };
 
+const RINKEBY_ADDRESSES: ContractAddresses = {
+    gatewayTokenController: '0x8769145499e1f97049e0099aF3d14283663C4Cf2',
+    flagsStorage: '0xf85d72EF898EbF82Ac1d7597CBb68a4d2898cE46',
+    forwarder: '0x2AaA24BaC2a41050dBA2474d6D9C4eaa1cdf9159',
+};
+
 const LOCALHOST_ADDRESSES: ContractAddresses = {
     gatewayTokenController: '0x5FbDB2315678afecb367f032d93F642f64180aa3',
     flagsStorage: '0x0',
@@ -25,5 +31,6 @@ const LOCALHOST_ADDRESSES: ContractAddresses = {
 export const addresses:{[key: number]: ContractAddresses}  = {
     1: MAINNET_ADDRESSES,
     3: ROPSTEN_ADDRESSES,
+    4: RINKEBY_ADDRESSES,
     1337: LOCALHOST_ADDRESSES,
 };

--- a/ethereum/gateway-eth-ts/src/lib/gatewaytokens.ts
+++ b/ethereum/gateway-eth-ts/src/lib/gatewaytokens.ts
@@ -24,6 +24,14 @@ const ROPSTEN_GATEWAY_TOKENS: GatewayTokenItem[] = [
     }
 ];
 
+const RINKEBY_GATEWAY_TOKENS: GatewayTokenItem[] = [
+  {
+    name: 'Test Gateway Token',
+    symbol: 'tKYC',
+    address: '0x182ae55852ffE71CaCA87aF3CFa8b4eF895dd051',
+  }
+];
+
 const LOCALHOST_GATEWAY_TOKENS: GatewayTokenItem[] = [
   {
     name: 'Test-KYC',
@@ -35,5 +43,6 @@ const LOCALHOST_GATEWAY_TOKENS: GatewayTokenItem[] = [
 export const gatewayTokenAddresses: {[key: number]: GatewayTokenItem[]} = {
   1: MAINNET_GATEWAY_TOKENS,
   3: ROPSTEN_GATEWAY_TOKENS,
+  4: RINKEBY_GATEWAY_TOKENS,
   1337: LOCALHOST_GATEWAY_TOKENS,
 }

--- a/ethereum/gateway-eth-ts/src/utils/constants.ts
+++ b/ethereum/gateway-eth-ts/src/utils/constants.ts
@@ -11,7 +11,7 @@ export const DEFAULT_CHAIN_ID = 3;
 export const DEFAULT_NETWORK = "ropsten";
 
 export const DEFAULT_GATEWAY_TOKEN =
-  "0xa3894BbA27f4Be571fFA319D02c122E021024cF2"; // Zambezi network on ropsten
+  "0x67306284Fb127E9baF713Ebf793d741cE763F81A";
 export const DEFAULT_MNEMONIC =
   "test test test test test test test test test test test junk";
 export const DEFAULT_GATEWAY_TOKEN_CONTROLLER =

--- a/ethereum/gateway-eth-ts/src/utils/constants.ts
+++ b/ethereum/gateway-eth-ts/src/utils/constants.ts
@@ -3,6 +3,7 @@ import { BigNumber } from "@ethersproject/bignumber";
 export const NETWORKS: { [key: number]: string } = {
   1: "mainnet",
   3: "ropsten",
+  4: "rinkeby",
   1337: "localhost",
 };
 
@@ -10,7 +11,7 @@ export const DEFAULT_CHAIN_ID = 3;
 export const DEFAULT_NETWORK = "ropsten";
 
 export const DEFAULT_GATEWAY_TOKEN =
-  "0x67306284Fb127E9baF713Ebf793d741cE763F81A";
+  "0xa3894BbA27f4Be571fFA319D02c122E021024cF2"; // Zambezi network on ropsten
 export const DEFAULT_MNEMONIC =
   "test test test test test test test test test test test junk";
 export const DEFAULT_GATEWAY_TOKEN_CONTROLLER =

--- a/ethereum/smart-contract/README.md
+++ b/ethereum/smart-contract/README.md
@@ -6,13 +6,31 @@ Gateway tokens allows Ethereum DeFi projects validate their users who succesfull
 
 ## Deployed contracts
 
+### Ropsten
+#### Zambezi network
+
 [GatewayTokenController](https://ropsten.etherscan.io/address/0x560691424bCEF5ceF4D5076C8ACA7B38B7b1f9A0)
 
 [FlagsStorage](https://ropsten.etherscan.io/address/0xC4ED3F939754f43555932AD2A2Ec1301d0848C07)
 
 [GatewayToken](https://ropsten.etherscan.io/address/0xa3894BbA27f4Be571fFA319D02c122E021024cF2)
 
+[Gatekeeper network authority](https://ropsten.etherscan.io/address/0xF32b1CAABFbaEe9173635433BCC9F43eD25d8Afc)
+
 [Forwarder](https://ropsten.etherscan.io/address/0x79C2bDD404e629828E3702a5f2cdd01FD5De8808)
+
+### Rinkeby
+#### Zambezi network
+
+[GatewayTokenController](https://rinkeby.etherscan.io/address/0x8769145499e1f97049e0099aF3d14283663C4Cf2)
+
+[FlagsStorage](https://rinkeby.etherscan.io/address/0xf85d72EF898EbF82Ac1d7597CBb68a4d2898cE46)
+
+[GatewayToken](https://rinkeby.etherscan.io/address/0x182ae55852ffE71CaCA87aF3CFa8b4eF895dd051)
+
+[Gatekeeper network authority](https://rinkeby.etherscan.io/address/0x9b4525aefEDA97b78559012ddA8163eF90B3dF21)
+
+[Forwarder](https://rinkeby.etherscan.io/address/0x2AaA24BaC2a41050dBA2474d6D9C4eaa1cdf9159)
 
 ## Quick Start
 


### PR DESCRIPTION
- Add rinkeby to list of chain id's
- Add rinkeby contract addresses to config and README.
- Allow provider OR signer to be passed in to GatewayETH constructor.