### PR TITLE
CIV-4874 Eth: Fix bug where GatewayTs was calling the wrong smart contract function

### DIFF
--- a/ethereum/gateway-eth-ts/src/GatewayTs.ts
+++ b/ethereum/gateway-eth-ts/src/GatewayTs.ts
@@ -206,7 +206,7 @@ export class GatewayTs extends GatewayTsBase {
     const expirationDate = getExpirationTime(expiry);
     const gatewayTxRequest = await populateTx(
       contract,
-      "refresh",
+      "setExpiration",
       [tokenId, expirationDate],
       options
     );


### PR DESCRIPTION
Eth: The smart contract function is called `setExpiration` , not `refresh` . GatewayTs was using a non-existent function.