### PR TITLE
Find all GTs

### DIFF
--- a/solana/gateway-ts/docs/classes/Active.html
+++ b/solana/gateway-ts/docs/classes/Active.html
@@ -111,7 +111,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Assignable.constructor</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/solanaBorsh.ts#L7">lib/solanaBorsh.ts:7</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/solanaBorsh.ts#L7">lib/solanaBorsh.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -143,7 +143,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Assignable.encode</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/solanaBorsh.ts#L16">lib/solanaBorsh.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/solanaBorsh.ts#L16">lib/solanaBorsh.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Buffer</span></h4>
@@ -161,7 +161,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Assignable.decode</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/solanaBorsh.ts#L20">lib/solanaBorsh.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/solanaBorsh.ts#L20">lib/solanaBorsh.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>

--- a/solana/gateway-ts/docs/classes/AssignablePublicKey.html
+++ b/solana/gateway-ts/docs/classes/AssignablePublicKey.html
@@ -133,7 +133,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Assignable.constructor</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/solanaBorsh.ts#L7">lib/solanaBorsh.ts:7</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/solanaBorsh.ts#L7">lib/solanaBorsh.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -160,7 +160,7 @@
 					<div class="tsd-signature tsd-kind-icon">bytes<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/AssignablePublicKey.ts#L15">lib/AssignablePublicKey.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/AssignablePublicKey.ts#L15">lib/AssignablePublicKey.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -178,7 +178,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Assignable.encode</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/solanaBorsh.ts#L16">lib/solanaBorsh.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/solanaBorsh.ts#L16">lib/solanaBorsh.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Buffer</span></h4>
@@ -195,7 +195,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/AssignablePublicKey.ts#L17">lib/AssignablePublicKey.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/AssignablePublicKey.ts#L17">lib/AssignablePublicKey.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">PublicKey</span></h4>
@@ -212,7 +212,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/AssignablePublicKey.ts#L21">lib/AssignablePublicKey.ts:21</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/AssignablePublicKey.ts#L21">lib/AssignablePublicKey.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4>
@@ -230,7 +230,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Assignable.decode</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/solanaBorsh.ts#L20">lib/solanaBorsh.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/solanaBorsh.ts#L20">lib/solanaBorsh.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -259,7 +259,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/AssignablePublicKey.ts#L35">lib/AssignablePublicKey.ts:35</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/AssignablePublicKey.ts#L35">lib/AssignablePublicKey.ts:35</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="AssignablePublicKey.html" class="tsd-signature-type" data-tsd-kind="Class">AssignablePublicKey</a></h4>
@@ -276,7 +276,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/AssignablePublicKey.ts#L29">lib/AssignablePublicKey.ts:29</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/AssignablePublicKey.ts#L29">lib/AssignablePublicKey.ts:29</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -299,7 +299,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/AssignablePublicKey.ts#L25">lib/AssignablePublicKey.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/AssignablePublicKey.ts#L25">lib/AssignablePublicKey.ts:25</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/solana/gateway-ts/docs/classes/Frozen.html
+++ b/solana/gateway-ts/docs/classes/Frozen.html
@@ -111,7 +111,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Assignable.constructor</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/solanaBorsh.ts#L7">lib/solanaBorsh.ts:7</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/solanaBorsh.ts#L7">lib/solanaBorsh.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -143,7 +143,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Assignable.encode</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/solanaBorsh.ts#L16">lib/solanaBorsh.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/solanaBorsh.ts#L16">lib/solanaBorsh.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Buffer</span></h4>
@@ -161,7 +161,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Assignable.decode</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/solanaBorsh.ts#L20">lib/solanaBorsh.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/solanaBorsh.ts#L20">lib/solanaBorsh.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>

--- a/solana/gateway-ts/docs/classes/GatewayInstruction.html
+++ b/solana/gateway-ts/docs/classes/GatewayInstruction.html
@@ -133,7 +133,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Enum.constructor</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/solanaBorsh.ts#L30">lib/solanaBorsh.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/solanaBorsh.ts#L30">lib/solanaBorsh.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">add<wbr>Feature<wbr>ToNetwork<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">AddFeatureToNetwork</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/instruction.ts#L45">lib/instruction.ts:45</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/instruction.ts#L45">lib/instruction.ts:45</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -165,7 +165,7 @@
 					<div class="tsd-signature tsd-kind-icon">add<wbr>Gatekeeper<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">AddGatekeeper</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/instruction.ts#L40">lib/instruction.ts:40</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/instruction.ts#L40">lib/instruction.ts:40</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -176,7 +176,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Enum.enum</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/solanaBorsh.ts#L28">lib/solanaBorsh.ts:28</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/solanaBorsh.ts#L28">lib/solanaBorsh.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -186,7 +186,7 @@
 					<div class="tsd-signature tsd-kind-icon">issue<wbr>Vanilla<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">IssueVanilla</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/instruction.ts#L41">lib/instruction.ts:41</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/instruction.ts#L41">lib/instruction.ts:41</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -196,7 +196,7 @@
 					<div class="tsd-signature tsd-kind-icon">remove<wbr>Feature<wbr>From<wbr>Network<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RemoveFeatureFromNetwork</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/instruction.ts#L46">lib/instruction.ts:46</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/instruction.ts#L46">lib/instruction.ts:46</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -206,7 +206,7 @@
 					<div class="tsd-signature tsd-kind-icon">revoke<wbr>Gatekeeper<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RevokeGatekeeper</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/instruction.ts#L44">lib/instruction.ts:44</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/instruction.ts#L44">lib/instruction.ts:44</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -216,7 +216,7 @@
 					<div class="tsd-signature tsd-kind-icon">set<wbr>State<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">SetState</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/instruction.ts#L42">lib/instruction.ts:42</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/instruction.ts#L42">lib/instruction.ts:42</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -226,7 +226,7 @@
 					<div class="tsd-signature tsd-kind-icon">update<wbr>Expiry<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">UpdateExpiry</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/instruction.ts#L43">lib/instruction.ts:43</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/instruction.ts#L43">lib/instruction.ts:43</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -244,7 +244,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Enum.encode</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/solanaBorsh.ts#L16">lib/solanaBorsh.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/solanaBorsh.ts#L16">lib/solanaBorsh.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Buffer</span></h4>
@@ -261,7 +261,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/instruction.ts#L101">lib/instruction.ts:101</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/instruction.ts#L101">lib/instruction.ts:101</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -284,7 +284,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/instruction.ts#L48">lib/instruction.ts:48</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/instruction.ts#L48">lib/instruction.ts:48</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="GatewayInstruction.html" class="tsd-signature-type" data-tsd-kind="Class">GatewayInstruction</a></h4>
@@ -302,7 +302,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Enum.decode</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/solanaBorsh.ts#L20">lib/solanaBorsh.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/solanaBorsh.ts#L20">lib/solanaBorsh.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -331,7 +331,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/instruction.ts#L71">lib/instruction.ts:71</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/instruction.ts#L71">lib/instruction.ts:71</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="GatewayInstruction.html" class="tsd-signature-type" data-tsd-kind="Class">GatewayInstruction</a></h4>
@@ -348,7 +348,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/instruction.ts#L54">lib/instruction.ts:54</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/instruction.ts#L54">lib/instruction.ts:54</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -374,7 +374,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/instruction.ts#L109">lib/instruction.ts:109</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/instruction.ts#L109">lib/instruction.ts:109</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -397,7 +397,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/instruction.ts#L63">lib/instruction.ts:63</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/instruction.ts#L63">lib/instruction.ts:63</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="GatewayInstruction.html" class="tsd-signature-type" data-tsd-kind="Class">GatewayInstruction</a></h4>
@@ -414,7 +414,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/instruction.ts#L95">lib/instruction.ts:95</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/instruction.ts#L95">lib/instruction.ts:95</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="GatewayInstruction.html" class="tsd-signature-type" data-tsd-kind="Class">GatewayInstruction</a></h4>
@@ -431,7 +431,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/instruction.ts#L79">lib/instruction.ts:79</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/instruction.ts#L79">lib/instruction.ts:79</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="GatewayInstruction.html" class="tsd-signature-type" data-tsd-kind="Class">GatewayInstruction</a></h4>
@@ -448,7 +448,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/instruction.ts#L87">lib/instruction.ts:87</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/instruction.ts#L87">lib/instruction.ts:87</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/solana/gateway-ts/docs/classes/GatewayToken.html
+++ b/solana/gateway-ts/docs/classes/GatewayToken.html
@@ -119,7 +119,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/types/index.ts#L15">types/index.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/types/index.ts#L15">types/index.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -215,7 +215,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/types/index.ts#L30">types/index.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/types/index.ts#L30">types/index.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -232,7 +232,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/types/index.ts#L26">types/index.ts:26</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/types/index.ts#L26">types/index.ts:26</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -249,7 +249,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/types/index.ts#L43">types/index.ts:43</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/types/index.ts#L43">types/index.ts:43</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -280,7 +280,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/types/index.ts#L35">types/index.ts:35</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/types/index.ts#L35">types/index.ts:35</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/solana/gateway-ts/docs/classes/GatewayTokenData.html
+++ b/solana/gateway-ts/docs/classes/GatewayTokenData.html
@@ -136,7 +136,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Assignable.constructor</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/solanaBorsh.ts#L7">lib/solanaBorsh.ts:7</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/solanaBorsh.ts#L7">lib/solanaBorsh.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -163,7 +163,7 @@
 					<div class="tsd-signature tsd-kind-icon">expiry<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">BN</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/GatewayTokenData.ts#L21">lib/GatewayTokenData.ts:21</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/GatewayTokenData.ts#L21">lib/GatewayTokenData.ts:21</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 					<div class="tsd-signature tsd-kind-icon">gatekeeper<wbr>Network<span class="tsd-signature-symbol">:</span> <a href="AssignablePublicKey.html" class="tsd-signature-type" data-tsd-kind="Class">AssignablePublicKey</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/GatewayTokenData.ts#L19">lib/GatewayTokenData.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/GatewayTokenData.ts#L19">lib/GatewayTokenData.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -183,7 +183,7 @@
 					<div class="tsd-signature tsd-kind-icon">issuing<wbr>Gatekeeper<span class="tsd-signature-symbol">:</span> <a href="AssignablePublicKey.html" class="tsd-signature-type" data-tsd-kind="Class">AssignablePublicKey</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/GatewayTokenData.ts#L18">lib/GatewayTokenData.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/GatewayTokenData.ts#L18">lib/GatewayTokenData.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -193,7 +193,7 @@
 					<div class="tsd-signature tsd-kind-icon">owner<span class="tsd-signature-symbol">:</span> <a href="AssignablePublicKey.html" class="tsd-signature-type" data-tsd-kind="Class">AssignablePublicKey</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/GatewayTokenData.ts#L17">lib/GatewayTokenData.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/GatewayTokenData.ts#L17">lib/GatewayTokenData.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -203,7 +203,7 @@
 					<div class="tsd-signature tsd-kind-icon">state<span class="tsd-signature-symbol">:</span> <a href="GatewayTokenState.html" class="tsd-signature-type" data-tsd-kind="Class">GatewayTokenState</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/GatewayTokenData.ts#L20">lib/GatewayTokenData.ts:20</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/GatewayTokenData.ts#L20">lib/GatewayTokenData.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -221,7 +221,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Assignable.encode</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/solanaBorsh.ts#L16">lib/solanaBorsh.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/solanaBorsh.ts#L16">lib/solanaBorsh.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Buffer</span></h4>
@@ -238,7 +238,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/GatewayTokenData.ts#L27">lib/GatewayTokenData.ts:27</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/GatewayTokenData.ts#L27">lib/GatewayTokenData.ts:27</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -262,7 +262,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Assignable.decode</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/solanaBorsh.ts#L20">lib/solanaBorsh.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/solanaBorsh.ts#L20">lib/solanaBorsh.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -291,7 +291,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/GatewayTokenData.ts#L34">lib/GatewayTokenData.ts:34</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/GatewayTokenData.ts#L34">lib/GatewayTokenData.ts:34</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -314,7 +314,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/GatewayTokenData.ts#L23">lib/GatewayTokenData.ts:23</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/GatewayTokenData.ts#L23">lib/GatewayTokenData.ts:23</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/solana/gateway-ts/docs/classes/GatewayTokenState.html
+++ b/solana/gateway-ts/docs/classes/GatewayTokenState.html
@@ -120,7 +120,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Enum.constructor</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/solanaBorsh.ts#L30">lib/solanaBorsh.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/solanaBorsh.ts#L30">lib/solanaBorsh.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -142,7 +142,7 @@
 					<div class="tsd-signature tsd-kind-icon">active<span class="tsd-signature-symbol">:</span> <a href="Active.html" class="tsd-signature-type" data-tsd-kind="Class">Active</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/GatewayTokenData.ts#L47">lib/GatewayTokenData.ts:47</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/GatewayTokenData.ts#L47">lib/GatewayTokenData.ts:47</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -153,7 +153,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Enum.enum</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/solanaBorsh.ts#L28">lib/solanaBorsh.ts:28</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/solanaBorsh.ts#L28">lib/solanaBorsh.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -163,7 +163,7 @@
 					<div class="tsd-signature tsd-kind-icon">frozen<span class="tsd-signature-symbol">:</span> <a href="Frozen.html" class="tsd-signature-type" data-tsd-kind="Class">Frozen</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/GatewayTokenData.ts#L48">lib/GatewayTokenData.ts:48</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/GatewayTokenData.ts#L48">lib/GatewayTokenData.ts:48</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 					<div class="tsd-signature tsd-kind-icon">revoked<span class="tsd-signature-symbol">:</span> <a href="Revoked.html" class="tsd-signature-type" data-tsd-kind="Class">Revoked</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/GatewayTokenData.ts#L49">lib/GatewayTokenData.ts:49</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/GatewayTokenData.ts#L49">lib/GatewayTokenData.ts:49</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -191,7 +191,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Enum.encode</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/solanaBorsh.ts#L16">lib/solanaBorsh.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/solanaBorsh.ts#L16">lib/solanaBorsh.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Buffer</span></h4>
@@ -209,7 +209,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Enum.decode</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/solanaBorsh.ts#L20">lib/solanaBorsh.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/solanaBorsh.ts#L20">lib/solanaBorsh.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>

--- a/solana/gateway-ts/docs/classes/NetworkFeature.html
+++ b/solana/gateway-ts/docs/classes/NetworkFeature.html
@@ -118,7 +118,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Enum.constructor</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/solanaBorsh.ts#L30">lib/solanaBorsh.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/solanaBorsh.ts#L30">lib/solanaBorsh.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -141,7 +141,7 @@
 					<aside class="tsd-sources">
 						<p>Inherited from Enum.enum</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/solanaBorsh.ts#L28">lib/solanaBorsh.ts:28</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/solanaBorsh.ts#L28">lib/solanaBorsh.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -151,7 +151,7 @@
 					<div class="tsd-signature tsd-kind-icon">user<wbr>Token<wbr>Expiry<span class="tsd-signature-symbol">:</span> <a href="UserTokenExpiry.html" class="tsd-signature-type" data-tsd-kind="Class">UserTokenExpiry</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/GatewayNetworkData.ts#L5">lib/GatewayNetworkData.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/GatewayNetworkData.ts#L5">lib/GatewayNetworkData.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -169,7 +169,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Enum.encode</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/solanaBorsh.ts#L16">lib/solanaBorsh.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/solanaBorsh.ts#L16">lib/solanaBorsh.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Buffer</span></h4>
@@ -187,7 +187,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Enum.decode</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/solanaBorsh.ts#L20">lib/solanaBorsh.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/solanaBorsh.ts#L20">lib/solanaBorsh.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>

--- a/solana/gateway-ts/docs/classes/Revoked.html
+++ b/solana/gateway-ts/docs/classes/Revoked.html
@@ -111,7 +111,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Assignable.constructor</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/solanaBorsh.ts#L7">lib/solanaBorsh.ts:7</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/solanaBorsh.ts#L7">lib/solanaBorsh.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -143,7 +143,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Assignable.encode</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/solanaBorsh.ts#L16">lib/solanaBorsh.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/solanaBorsh.ts#L16">lib/solanaBorsh.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Buffer</span></h4>
@@ -161,7 +161,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Assignable.decode</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/solanaBorsh.ts#L20">lib/solanaBorsh.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/solanaBorsh.ts#L20">lib/solanaBorsh.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>

--- a/solana/gateway-ts/docs/classes/UserTokenExpiry.html
+++ b/solana/gateway-ts/docs/classes/UserTokenExpiry.html
@@ -111,7 +111,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Assignable.constructor</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/solanaBorsh.ts#L7">lib/solanaBorsh.ts:7</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/solanaBorsh.ts#L7">lib/solanaBorsh.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -143,7 +143,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Assignable.encode</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/solanaBorsh.ts#L16">lib/solanaBorsh.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/solanaBorsh.ts#L16">lib/solanaBorsh.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Buffer</span></h4>
@@ -161,7 +161,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from Assignable.decode</p>
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/solanaBorsh.ts#L20">lib/solanaBorsh.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/solanaBorsh.ts#L20">lib/solanaBorsh.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>

--- a/solana/gateway-ts/docs/enums/State.html
+++ b/solana/gateway-ts/docs/enums/State.html
@@ -88,7 +88,7 @@
 					<div class="tsd-signature tsd-kind-icon">ACTIVE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;ACTIVE&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/types/index.ts#L10">types/index.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/types/index.ts#L10">types/index.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -98,7 +98,7 @@
 					<div class="tsd-signature tsd-kind-icon">FROZEN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;FROZEN&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/types/index.ts#L12">types/index.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/types/index.ts#L12">types/index.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -108,7 +108,7 @@
 					<div class="tsd-signature tsd-kind-icon">REVOKED<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;REVOKED&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/types/index.ts#L11">types/index.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/types/index.ts#L11">types/index.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/solana/gateway-ts/docs/index.html
+++ b/solana/gateway-ts/docs/index.html
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">Deep<wbr>Partial&lt;T&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{</span><span class="tsd-signature-symbol">[ </span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol"> in </span><span class="tsd-signature-symbol">keyof </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">: </span><a href="index.html#DeepPartial" class="tsd-signature-type" data-tsd-kind="Type alias">DeepPartial</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-type">P</span><span class="tsd-signature-symbol">]</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/types/index.ts#L5">types/index.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/types/index.ts#L5">types/index.ts:5</a></li>
 						</ul>
 					</aside>
 					<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -155,7 +155,7 @@
 					<div class="tsd-signature tsd-kind-icon">Program<wbr>Account<wbr>Response<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>account<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">AccountInfo</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Buffer</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">; </span>pubkey<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">PublicKey</span><span class="tsd-signature-symbol"> }</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/types/index.ts#L62">types/index.ts:62</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/types/index.ts#L62">types/index.ts:62</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -179,7 +179,7 @@
 					<div class="tsd-signature tsd-kind-icon">DEFAULT_<wbr>SOLANA_<wbr>RETRIES<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 3</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/constants.ts#L11">lib/constants.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/constants.ts#L11">lib/constants.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -189,7 +189,7 @@
 					<div class="tsd-signature tsd-kind-icon">GATEKEEPER_<wbr>NONCE_<wbr>SEED_<wbr>STRING<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">&quot;gatekeeper&quot;</span><span class="tsd-signature-symbol"> = &quot;gatekeeper&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/constants.ts#L7">lib/constants.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/constants.ts#L7">lib/constants.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -199,7 +199,7 @@
 					<div class="tsd-signature tsd-kind-icon">GATEWAY_<wbr>TOKEN_<wbr>ADDRESS_<wbr>SEED<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">&quot;gateway&quot;</span><span class="tsd-signature-symbol"> = &quot;gateway&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/constants.ts#L8">lib/constants.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/constants.ts#L8">lib/constants.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -209,7 +209,7 @@
 					<div class="tsd-signature tsd-kind-icon">PROGRAM_<wbr>ID<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">PublicKey</span><span class="tsd-signature-symbol"> = ...</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/constants.ts#L4">lib/constants.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/constants.ts#L4">lib/constants.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -219,7 +219,7 @@
 					<div class="tsd-signature tsd-kind-icon">SOLANA_<wbr>COMMITMENT<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Commitment</span><span class="tsd-signature-symbol"> = &quot;confirmed&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/constants.ts#L10">lib/constants.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/constants.ts#L10">lib/constants.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -229,7 +229,7 @@
 					<div class="tsd-signature tsd-kind-icon">SOLANA_<wbr>TIMEOUT_<wbr>CONFIRMED<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">7000</span><span class="tsd-signature-symbol"> = 7000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/constants.ts#L14">lib/constants.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/constants.ts#L14">lib/constants.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -239,7 +239,7 @@
 					<div class="tsd-signature tsd-kind-icon">SOLANA_<wbr>TIMEOUT_<wbr>FINALIZED<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">10000</span><span class="tsd-signature-symbol"> = 10000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/constants.ts#L15">lib/constants.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/constants.ts#L15">lib/constants.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -249,7 +249,7 @@
 					<div class="tsd-signature tsd-kind-icon">SOLANA_<wbr>TIMEOUT_<wbr>PROCESSED<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">3000</span><span class="tsd-signature-symbol"> = 3000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/constants.ts#L13">lib/constants.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/constants.ts#L13">lib/constants.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -266,7 +266,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/instruction.ts#L338">lib/instruction.ts:338</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/instruction.ts#L338">lib/instruction.ts:338</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -310,7 +310,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/instruction.ts#L127">lib/instruction.ts:127</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/instruction.ts#L127">lib/instruction.ts:127</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -360,7 +360,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/util.ts#L86">lib/util.ts:86</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/util.ts#L88">lib/util.ts:88</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -386,7 +386,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/util.ts#L286">lib/util.ts:286</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/util.ts#L310">lib/util.ts:310</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -401,11 +401,14 @@
 								</li>
 								<li>
 									<h5>feature: <a href="classes/NetworkFeature.html" class="tsd-signature-type" data-tsd-kind="Class">NetworkFeature</a></h5>
+									<div class="tsd-comment tsd-typography">
+										<p>The feature to check</p>
+									</div>
 								</li>
 								<li>
 									<h5>network: <span class="tsd-signature-type">PublicKey</span></h5>
 									<div class="tsd-comment tsd-typography">
-										<p>The network</p>
+										<p>The gatekeeper network</p>
 									</div>
 								</li>
 							</ul>
@@ -423,7 +426,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/util.ts#L157">lib/util.ts:157</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/util.ts#L180">lib/util.ts:180</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -461,18 +464,18 @@
 					<a name="findGatewayTokens" class="tsd-anchor"></a>
 					<h3><span class="tsd-flag ts-flagConst">Const</span> find<wbr>Gateway<wbr>Tokens</h3>
 					<ul class="tsd-signatures tsd-kind-function">
-						<li class="tsd-signature tsd-kind-icon">find<wbr>Gateway<wbr>Tokens<span class="tsd-signature-symbol">(</span>connection<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Connection</span>, owner<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">PublicKey</span>, gatekeeperNetwork<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">PublicKey</span>, includeRevoked<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="classes/GatewayToken.html" class="tsd-signature-type" data-tsd-kind="Class">GatewayToken</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></li>
+						<li class="tsd-signature tsd-kind-icon">find<wbr>Gateway<wbr>Tokens<span class="tsd-signature-symbol">(</span>connection<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Connection</span>, owner<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">PublicKey</span>, gatekeeperNetwork<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">PublicKey</span>, includeRevoked<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">boolean</span>, page<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="classes/GatewayToken.html" class="tsd-signature-type" data-tsd-kind="Class">GatewayToken</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/util.ts#L112">lib/util.ts:112</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/util.ts#L115">lib/util.ts:115</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
-									<p>Find all gateway tokens for a user on a gatekeeper network, optionally filtering out revoked tokens.</p>
+									<p>Find all gateway tokens (optionally for a user) on a gatekeeper network, optionally filtering out revoked tokens.</p>
 								</div>
 								<p>Warning - this uses the Solana getProgramAccounts RPC endpoint, which is inefficient and may be
 								blocked by some RPC services.</p>
@@ -486,9 +489,9 @@
 									</div>
 								</li>
 								<li>
-									<h5>owner: <span class="tsd-signature-type">PublicKey</span></h5>
+									<h5>owner: <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">PublicKey</span></h5>
 									<div class="tsd-comment tsd-typography">
-										<p>The token owner</p>
+										<p>The token owner (optional)</p>
 									</div>
 								</li>
 								<li>
@@ -502,6 +505,9 @@
 									<div class="tsd-comment tsd-typography">
 										<p>If false (default), filter out revoked tokens</p>
 									</div>
+								</li>
+								<li>
+									<h5><span class="tsd-flag ts-flagOptional">Optional</span> page: <span class="tsd-signature-type">number</span></h5>
 								</li>
 							</ul>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="classes/GatewayToken.html" class="tsd-signature-type" data-tsd-kind="Class">GatewayToken</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -519,7 +525,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/instruction.ts#L261">lib/instruction.ts:261</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/instruction.ts#L261">lib/instruction.ts:261</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -563,7 +569,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/util.ts#L246">lib/util.ts:246</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/util.ts#L269">lib/util.ts:269</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -606,7 +612,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/util.ts#L268">lib/util.ts:268</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/util.ts#L291">lib/util.ts:291</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -640,7 +646,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/util.ts#L23">lib/util.ts:23</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/util.ts#L25">lib/util.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -677,7 +683,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/util.ts#L223">lib/util.ts:223</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/util.ts#L246">lib/util.ts:246</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -714,7 +720,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/util.ts#L44">lib/util.ts:44</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/util.ts#L46">lib/util.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -757,7 +763,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/instruction.ts#L191">lib/instruction.ts:191</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/instruction.ts#L191">lib/instruction.ts:191</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -832,7 +838,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/GatewayNetworkData.ts#L15">lib/GatewayNetworkData.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/GatewayNetworkData.ts#L15">lib/GatewayNetworkData.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -855,7 +861,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/util.ts#L188">lib/util.ts:188</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/util.ts#L211">lib/util.ts:211</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -923,7 +929,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/util.ts#L213">lib/util.ts:213</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/util.ts#L236">lib/util.ts:236</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -960,7 +966,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/instruction.ts#L366">lib/instruction.ts:366</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/instruction.ts#L366">lib/instruction.ts:366</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1004,7 +1010,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/instruction.ts#L236">lib/instruction.ts:236</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/instruction.ts#L236">lib/instruction.ts:236</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1048,7 +1054,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/instruction.ts#L158">lib/instruction.ts:158</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/instruction.ts#L158">lib/instruction.ts:158</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1098,7 +1104,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/instruction.ts#L286">lib/instruction.ts:286</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/instruction.ts#L286">lib/instruction.ts:286</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1142,7 +1148,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/5c21b84/solana/gateway-ts/src/lib/instruction.ts#L312">lib/instruction.ts:312</a></li>
+									<li>Defined in <a href="https://github.com/identity-com/on-chain-identity-gateway/blob/1779578/solana/gateway-ts/src/lib/instruction.ts#L312">lib/instruction.ts:312</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/solana/gateway-ts/package.json
+++ b/solana/gateway-ts/package.json
@@ -23,6 +23,7 @@
     "async-retry": "^1.3.3",
     "bn.js": "^5.2.0",
     "borsh": "^0.4.0",
+    "bs58": "^5.0.0",
     "ramda": "^0.27.1"
   },
   "devDependencies": {

--- a/solana/gateway-ts/scripts/findGatewayTokens.ts
+++ b/solana/gateway-ts/scripts/findGatewayTokens.ts
@@ -1,42 +1,79 @@
-import { homedir } from "os";
-import * as path from "path";
-import { Connection, Keypair, PublicKey } from "@solana/web3.js";
+/**
+ * Get all gateway tokens on a given network (optionally for a given wallet)
+ *
+ * ## Usage
+ * ```
+ * yarn ts-node scripts/findGatewayTokens.ts <gatekeeperNetwork> [walletAddress]
+ * ```
+ *
+ * Use a custom RPC endpoint by setting the CLUSTER_ENDPOINT environment variable.
+ *
+ * ## Pagination
+ *
+ * If a large number of tokens has been issued, the request to the RPC endpoint may time out.
+ * In this case, enable pagination by setting the PAGINATE=1 environment variable.
+ * Pagination is not supported in the RPC API, but this approximates it by
+ * adding another filter on the first byte of the owner address.
+ * Each page requests the accounts that match the next byte.
+ */
+
+import { clusterApiUrl, Connection, PublicKey } from "@solana/web3.js";
 import { findGatewayTokens, GatewayToken } from "../src";
 
-const mySecretKey = require(path.join(
-  homedir(),
-  ".config",
-  "solana",
-  "id.json"
-));
-const myKeypair = Keypair.fromSecretKey(Buffer.from(mySecretKey));
+const SEPARATOR = ",";
+
+const [gatekeeperNetworkString, walletAddressString] = process.argv.slice(2);
+
+if (!gatekeeperNetworkString) throw new Error("Missing gatekeeper network");
 
 // default to the civic cluster
-const endpoint =
-  process.env.CLUSTER_ENDPOINT ||
-  "http://ec2-34-238-243-215.compute-1.amazonaws.com:8899";
-
+const endpoint = process.env.CLUSTER_ENDPOINT || clusterApiUrl("mainnet-beta");
 const connection = new Connection(endpoint, "processed");
 
-// Gatekeeper Network
-const gatekeeperNetworkKey = new PublicKey(
-  "48V9nmW9awiR9BmihdGhUL3ZpYJ8MCgGeUoSWbtqjicv"
-);
+const gatekeeperNetwork = new PublicKey(gatekeeperNetworkString);
+const walletAddress = walletAddressString
+  ? new PublicKey(walletAddressString)
+  : undefined;
 
-const prettyPrint = (gatewayToken: GatewayToken) => ({
+const extractData = (gatewayToken: GatewayToken) => ({
   owner: gatewayToken.owner.toBase58(),
   gatekeeperNetwork: gatewayToken.gatekeeperNetwork.toBase58(),
   gatekeeper: gatewayToken.issuingGatekeeper.toBase58(),
-  valid: gatewayToken.isValid,
+  valid: gatewayToken.isValid(),
 });
 
-(async function () {
-  console.log("My pubkey as a byte array: ", myKeypair.publicKey.toBuffer());
-  const accounts = await findGatewayTokens(
+const prettyPrint = (extractedGatewayToken: ReturnType<typeof extractData>) =>
+  `${extractedGatewayToken.owner}${SEPARATOR}${extractedGatewayToken.gatekeeperNetwork}${SEPARATOR}${extractedGatewayToken.gatekeeper}${SEPARATOR}${extractedGatewayToken.valid}`;
+
+const fetchPage = async (page?: number): Promise<GatewayToken[]> => {
+  const tokens = await findGatewayTokens(
     connection,
-    myKeypair.publicKey,
-    gatekeeperNetworkKey
+    walletAddress,
+    gatekeeperNetwork,
+    false,
+    page
   );
-  console.log("Found Accounts");
-  console.log(accounts.map(prettyPrint));
+
+  if (tokens.length > 0) {
+    tokens
+      .map(extractData)
+      .map(prettyPrint)
+      .forEach((t) => console.log(t));
+  }
+
+  return tokens;
+};
+
+(async () => {
+  console.log(
+    `Owner${SEPARATOR}Gatekeeper Network${SEPARATOR}Issuing Gatekeeper${SEPARATOR}Valid`
+  );
+  if (process.env.PAGINATE) {
+    for (let i = 0; i <= 255; i++) {
+      console.error(`Page ${i + 1}/256`);
+      await fetchPage(i);
+    }
+  } else {
+    await fetchPage();
+  }
 })().catch((error) => console.error(error));

--- a/solana/yarn.lock
+++ b/solana/yarn.lock
@@ -1494,6 +1494,11 @@ base-x@^3.0.2, base-x@^3.0.6:
   dependencies:
     safe-buffer "^5.0.1"
 
+base-x@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-4.0.0.tgz#d0e3b7753450c73f8ad2389b5c018a4af7b2224a"
+  integrity sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==
+
 base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -1648,6 +1653,13 @@ bs58@^4.0.0, bs58@^4.0.1:
   integrity sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==
   dependencies:
     base-x "^3.0.2"
+
+bs58@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/bs58/-/bs58-5.0.0.tgz#865575b4d13c09ea2a84622df6c8cbeb54ffc279"
+  integrity sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==
+  dependencies:
+    base-x "^4.0.0"
 
 buffer-alloc-unsafe@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Sol: Adapted existing findGatewayTokens.ts script and function to allow finding *all* gateway tokens for a given gkn.

Script usage:


```
yarn ts-node scripts/findGatewayTokens.ts <gatekeeperNetwork> [walletAddress]
```

Use a custom RPC endpoint by setting the CLUSTER_ENDPOINT environment variable.

Pagination

If a large number of tokens has been issued, the request to the RPC endpoint may time out.
In this case, enable pagination by setting the PAGINATE=1 environment variable.
Pagination is not supported in the RPC API, but this approximates it by adding another filter on the first byte of the owner address.
Each page requests the accounts that match the next byte.