### PR TITLE
Feature/idcom 2221  jsdoc documentation update

### DIFF
--- a/solana/program_v2/packages/client/core/src/lib/utils.ts
+++ b/solana/program_v2/packages/client/core/src/lib/utils.ts
@@ -73,7 +73,16 @@ export const findProgramAddress = async (
     GATEWAY_PROGRAM
   );
 
-export const findGatewayToken = async (
+/**
+ * Finds a gateway pass for a given subject
+ *
+ * @param connection The Solana connection to use
+ * @param gatekeeperNetwork The gatekeeper network the pass is in
+ * @param subject The address for the subject the pass belongs to
+ * @param passNumber The pass number if more than one pass is issued
+ * @param opts The Solana confirm options to use
+ */
+export const findGatewayPass = async (
   connection: Connection,
   gatekeeperNetwork: PublicKey,
   subject: PublicKey,
@@ -92,7 +101,16 @@ export const findGatewayToken = async (
   return program.account.pass.fetchNullable(address).then(PassAccount.from);
 };
 
-export const onGatewayToken = async (
+/**
+ * Fires an event when a gateway pass is issued or updated
+ *
+ * @param connection The Solana connection to use
+ * @param gatekeeperNetwork The gatekeeper network the pass is in
+ * @param subject The address for the subject the pass belongs to
+ * @param passNumber The pass number if more than one pass is issued
+ * @param opts The Solana confirm options to use
+ */
+export const onGatewayPass = async (
   connection: Connection,
   network: PublicKey,
   subject: PublicKey,

--- a/solana/program_v2/packages/client/core/src/lib/utils.ts
+++ b/solana/program_v2/packages/client/core/src/lib/utils.ts
@@ -108,11 +108,12 @@ export const findGatewayPass = async (
  * @param gatekeeperNetwork The gatekeeper network the pass is in
  * @param subject The address for the subject the pass belongs to
  * @param passNumber The pass number if more than one pass is issued
+ * @param callback The function called when the pass is issued or updated
  * @param opts The Solana confirm options to use
  */
 export const onGatewayPass = async (
   connection: Connection,
-  network: PublicKey,
+  gatekeeperNetwork: PublicKey,
   subject: PublicKey,
   passNumber = 0,
   callback: (pass: PassAccount) => void,

--- a/solana/program_v2/packages/client/core/src/lib/utils.ts
+++ b/solana/program_v2/packages/client/core/src/lib/utils.ts
@@ -124,7 +124,7 @@ export const onGatewayPass = async (
 
   const address = await GatekeeperService.createPassAddress(
     subject,
-    network,
+    gatekeeperNetwork,
     passNumber
   );
 

--- a/solana/program_v2/packages/client/core/src/utils/AbstractService.ts
+++ b/solana/program_v2/packages/client/core/src/utils/AbstractService.ts
@@ -20,6 +20,9 @@ import { Wallet } from '../lib/types';
 import { ExtendedCluster } from '../lib/connection';
 import { GATEWAY_PROGRAM, SOLANA_MAINNET } from '../lib/constants';
 
+/**
+ * The AbstractService provides base functionality for other services
+ */
 export abstract class AbstractService {
   protected constructor(
     protected _program: Program<SolanaAnchorGateway>,
@@ -28,6 +31,11 @@ export abstract class AbstractService {
     protected _opts: ConfirmOptions = AnchorProvider.defaultOptions()
   ) {}
 
+  /**
+   * Fetches an instance of the Anchor Program based on the provider
+   *
+   * @param provider The provider to create the program from
+   */
   static async fetchProgram(
     provider: anchor.Provider
   ): Promise<Program<SolanaAnchorGateway>> {
@@ -38,27 +46,45 @@ export abstract class AbstractService {
     ) as Program<SolanaAnchorGateway>;
   }
 
+  /**
+   * Gets the wallet used for the service
+   */
   getWallet(): Wallet {
     return this._wallet;
   }
 
+  /**
+   * Gets the program used for the service
+   */
   getProgram(): Program<SolanaAnchorGateway> {
     return this._program;
   }
 
+  /**
+   * Gets the connection used for the service
+   */
   getConnection(): Connection {
     return this._program.provider.connection;
   }
 
+  /**
+   * Gets the solana confirm options used for the service
+   */
   getConfirmOptions(): ConfirmOptions {
     return this._opts;
   }
 
+  /**
+   * Gets the IDL used for the service
+   */
   getIdl(): Idl {
     return this._program.idl;
   }
 }
 
+/**
+ * A non-signing wallet used if no signing functionality is required
+ */
 export class NonSigningWallet implements Wallet {
   publicKey: PublicKey;
 
@@ -81,6 +107,9 @@ export class NonSigningWallet implements Wallet {
   }
 }
 
+/**
+ * The ServiceBuilder is used to provide a builder to create and execute instructions
+ */
 export class ServiceBuilder {
   private wallet: Wallet;
   private connection: Connection;
@@ -100,36 +129,56 @@ export class ServiceBuilder {
     this.idlErrors = parseIdlErrors(service.getIdl());
   }
 
+  /**
+   * Gets the intruction to be executed
+   */
   get instruction(): BuilderInstruction {
     return this._instruction;
   }
 
+  /**
+   * Allows providing an alternative connection to be used when executing the instruction
+   *
+   * @param connection The connection to use
+   */
   withConnection(connection: Connection): ServiceBuilder {
     this.connection = connection;
     return this;
   }
 
+  /**
+   * Allows providing an alternative confirm options to be used when executing the instruction
+   *
+   * @param confirmOptions The confirm options to use
+   */
   withConfirmOptions(confirmOptions: ConfirmOptions): ServiceBuilder {
     this.confirmOptions = confirmOptions;
     return this;
   }
 
+  /**
+   * Allows providing an alternative wallet to be used when executing the instruction
+   *
+   * @param wallet The wallet to use
+   */
   withWallet(wallet: Wallet): ServiceBuilder {
     this.wallet = wallet;
     return this;
   }
 
-  // TODO
-  withAutomaticAlloc(payer: PublicKey): ServiceBuilder {
-    this.authority = payer;
-    return this;
-  }
-
+  /**
+   * Allows providing additional signers when executing the instruction
+   *
+   * @param signers The signers to use
+   */
   withPartialSigners(...signers: Signer[]): ServiceBuilder {
     this.partialSigners = signers;
     return this;
   }
 
+  /**
+   * Returns the transaction for the instructions
+   */
   async transaction(): Promise<Transaction> {
     const tx = new Transaction();
     const instructions = await this._instruction.instructionPromise;
@@ -137,6 +186,11 @@ export class ServiceBuilder {
     return tx;
   }
 
+  /**
+   * Executes the instruction this service builder was created for
+   *
+   * @param opts Optionally allows overriding the confirm options
+   */
   async rpc(opts?: ConfirmOptions): Promise<string> {
     const provider = new AnchorProvider(
       this.connection,

--- a/solana/program_v2/packages/tests/src/pass-suite/issue.test.ts
+++ b/solana/program_v2/packages/tests/src/pass-suite/issue.test.ts
@@ -2,8 +2,8 @@ import {
   GatekeeperService,
   PassAccount,
   PassState,
-  onGatewayToken,
-  findGatewayToken,
+  onGatewayPass,
+  findGatewayPass,
 } from '@identity.com/gateway-solana-client';
 import { TEST_GATEKEEPER, TEST_NETWORK } from '../util/constants';
 import chai from 'chai';
@@ -54,7 +54,7 @@ describe('Issue pass', () => {
 
     const subject = Keypair.generate().publicKey;
 
-    const subscriptionId = await onGatewayToken(
+    const subscriptionId = await onGatewayPass(
       service.getConnection(),
       TEST_NETWORK,
       subject,
@@ -83,7 +83,7 @@ describe('Issue pass', () => {
     );
 
     await service.issue(account, subject).rpc();
-    const pass = await findGatewayToken(
+    const pass = await findGatewayPass(
       service.getConnection(),
       TEST_NETWORK,
       subject


### PR DESCRIPTION
* Additional documentation
* Renamed `token` to `pass` for consistency
* Removed remaining client side auto-alloc functionality