### PR TITLE
solana/program_v2: Add constraint to mint_account on pass instructions

### DIFF
--- a/solana/program_v2/packages/client/idl/src/solana_anchor_gateway.ts
+++ b/solana/program_v2/packages/client/idl/src/solana_anchor_gateway.ts
@@ -354,11 +354,6 @@ export type SolanaAnchorGateway = {
           "isSigner": true
         },
         {
-          "name": "network",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
           "name": "gatekeeper",
           "isMut": false,
           "isSigner": false
@@ -1505,6 +1500,11 @@ export type SolanaAnchorGateway = {
       "code": 6007,
       "name": "FeesNotProvided",
       "msg": "Network Fee was not provided"
+    },
+    {
+      "code": 6008,
+      "name": "TokenNotSupported",
+      "msg": "Token not supported"
     }
   ]
 };
@@ -1865,11 +1865,6 @@ export const IDL: SolanaAnchorGateway = {
           "isSigner": true
         },
         {
-          "name": "network",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
           "name": "gatekeeper",
           "isMut": false,
           "isSigner": false
@@ -3016,6 +3011,11 @@ export const IDL: SolanaAnchorGateway = {
       "code": 6007,
       "name": "FeesNotProvided",
       "msg": "Network Fee was not provided"
+    },
+    {
+      "code": 6008,
+      "name": "TokenNotSupported",
+      "msg": "Token not supported"
     }
   ]
 };

--- a/solana/program_v2/packages/tests/src/test-set-up.ts
+++ b/solana/program_v2/packages/tests/src/test-set-up.ts
@@ -124,7 +124,7 @@ export const setUpAdminNetworkGatekeeper = async (
       authKeys: [
         { flags: NetworkKeyFlags.AUTH, key: networkAuthority.publicKey },
       ],
-      supportedTokens: [],
+      supportedTokens: [{ key: mint, settlementInfo: { placeholder: 9 } }],
     })
     .withPartialSigners(networkAuthority)
     .rpc();

--- a/solana/program_v2/programs/gateway_v2/src/errors.rs
+++ b/solana/program_v2/programs/gateway_v2/src/errors.rs
@@ -18,6 +18,8 @@ pub enum NetworkErrors {
     AccountInUse,
     #[msg("Network Fee was not provided")]
     FeesNotProvided,
+    #[msg("Token not supported")]
+    TokenNotSupported,
 }
 
 #[error_code]

--- a/solana/program_v2/programs/gateway_v2/src/instructions/gatekeeper/expire_pass.rs
+++ b/solana/program_v2/programs/gateway_v2/src/instructions/gatekeeper/expire_pass.rs
@@ -2,6 +2,7 @@ use anchor_lang::prelude::*;
 use anchor_spl::token::{Mint, Token, TokenAccount};
 
 use crate::constants::{GATEKEEPER_SEED, PASS_SEED};
+use crate::errors::NetworkErrors;
 use crate::state::{Gatekeeper, GatekeeperKeyFlags, GatekeeperNetwork, Pass};
 use crate::util::{
     calculate_network_and_gatekeeper_fee, create_and_invoke_transfer, get_gatekeeper_fees,
@@ -72,8 +73,7 @@ pub struct PassExpire<'info> {
     pub funder: Signer<'info>,
     pub authority: Signer<'info>,
     pub spl_token_program: Program<'info, Token>,
-    // TODO: I actually would prefer to use a constraint for mint account verification, even if it
-    // requires a little overhead.
+    #[account(constraint = network.is_token_supported(&mint_account.key()) @ NetworkErrors::TokenNotSupported)]
     pub mint_account: Account<'info, Mint>,
     #[account(mut)]
     pub funder_token_account: Account<'info, TokenAccount>,

--- a/solana/program_v2/programs/gateway_v2/src/instructions/gatekeeper/issue_pass.rs
+++ b/solana/program_v2/programs/gateway_v2/src/instructions/gatekeeper/issue_pass.rs
@@ -3,6 +3,7 @@ use anchor_lang::Key;
 use anchor_spl::token::{Mint, Token, TokenAccount};
 
 use crate::constants::{GATEKEEPER_SEED, PASS_SEED};
+use crate::errors::NetworkErrors;
 use crate::state::{Gatekeeper, GatekeeperKeyFlags, GatekeeperNetwork, Pass, PassState};
 use crate::util::{
     calculate_network_and_gatekeeper_fee, create_and_invoke_transfer, get_gatekeeper_fees,

--- a/solana/program_v2/programs/gateway_v2/src/instructions/gatekeeper/issue_pass.rs
+++ b/solana/program_v2/programs/gateway_v2/src/instructions/gatekeeper/issue_pass.rs
@@ -85,8 +85,7 @@ pub struct IssuePass<'info> {
     pub funder: Signer<'info>,
     pub system_program: Program<'info, System>,
     pub spl_token_program: Program<'info, Token>,
-    // TODO: I actually would prefer to use a constraint for mint account verification, even if it
-    // requires a little overhead.
+    #[account(constraint = network.is_token_supported(&mint_account.key()) @ NetworkErrors::TokenNotSupported)]
     pub mint_account: Account<'info, Mint>,
     #[account(mut)]
     pub funder_token_account: Account<'info, TokenAccount>,

--- a/solana/program_v2/programs/gateway_v2/src/instructions/gatekeeper/refresh_pass.rs
+++ b/solana/program_v2/programs/gateway_v2/src/instructions/gatekeeper/refresh_pass.rs
@@ -70,8 +70,7 @@ pub struct PassRefresh<'info> {
     )]
     pub gatekeeper: Box<Account<'info, Gatekeeper>>,
     pub spl_token_program: Program<'info, Token>,
-    // TODO: I actually would prefer to use a constraint for mint account verification, even if it
-    // requires a little overhead.
+    #[account(constraint = network.is_token_supported(&mint_account.key()) @ NetworkErrors::TokenNotSupported)]
     pub mint_account: Account<'info, Mint>,
     #[account(mut)]
     pub funder_token_account: Account<'info, TokenAccount>,

--- a/solana/program_v2/programs/gateway_v2/src/instructions/gatekeeper/refresh_pass.rs
+++ b/solana/program_v2/programs/gateway_v2/src/instructions/gatekeeper/refresh_pass.rs
@@ -2,6 +2,7 @@ use anchor_lang::prelude::*;
 use anchor_spl::token::{Mint, Token, TokenAccount};
 
 use crate::constants::{GATEKEEPER_SEED, PASS_SEED};
+use crate::errors::NetworkErrors;
 use crate::state::{Gatekeeper, GatekeeperKeyFlags, GatekeeperNetwork, Pass};
 use crate::util::{
     calculate_network_and_gatekeeper_fee, create_and_invoke_transfer, get_gatekeeper_fees,

--- a/solana/program_v2/programs/gateway_v2/src/instructions/gatekeeper/verify_pass.rs
+++ b/solana/program_v2/programs/gateway_v2/src/instructions/gatekeeper/verify_pass.rs
@@ -73,8 +73,7 @@ pub struct PassVerify<'info> {
     pub funder: Signer<'info>,
     pub authority: Signer<'info>,
     pub spl_token_program: Program<'info, Token>,
-    // TODO: I actually would prefer to use a constraint for mint account verification, even if it
-    // requires a little overhead.
+    #[account(constraint = network.is_token_supported(&mint_account.key()) @ NetworkErrors::TokenNotSupported)]
     pub mint_account: Account<'info, Mint>,
     #[account(mut)]
     pub funder_token_account: Account<'info, TokenAccount>,

--- a/solana/program_v2/programs/gateway_v2/src/instructions/gatekeeper/verify_pass.rs
+++ b/solana/program_v2/programs/gateway_v2/src/instructions/gatekeeper/verify_pass.rs
@@ -2,6 +2,7 @@ use anchor_lang::prelude::*;
 use anchor_spl::token::{Mint, Token, TokenAccount};
 
 use crate::constants::{GATEKEEPER_SEED, PASS_SEED};
+use crate::errors::NetworkErrors;
 use crate::state::{Gatekeeper, GatekeeperKeyFlags, GatekeeperNetwork, Pass};
 use crate::util::{
     calculate_network_and_gatekeeper_fee, create_and_invoke_transfer, get_gatekeeper_fees,

--- a/solana/program_v2/programs/gateway_v2/src/state/network.rs
+++ b/solana/program_v2/programs/gateway_v2/src/state/network.rs
@@ -99,6 +99,12 @@ impl GatekeeperNetwork {
             > 0
     }
 
+    pub fn is_token_supported(&self, mint_account: &Pubkey) -> bool {
+        self.supported_tokens
+            .iter()
+            .any(|token| token.key == *mint_account)
+    }
+
     pub fn set_expire_time(
         &mut self,
         data: &UpdateNetworkData,


### PR DESCRIPTION
Added constraint to mint_account so users can't pass in a mint account that is not supported by the network