### PR TITLE
solana/program_v2: Remove network_bump

### DIFF
--- a/solana/program_v2/packages/client/idl/src/solana_anchor_gateway.ts
+++ b/solana/program_v2/packages/client/idl/src/solana_anchor_gateway.ts
@@ -737,13 +737,6 @@ export type SolanaAnchorGateway = {
             "type": "u16"
           },
           {
-            "name": "networkBump",
-            "docs": [
-              "The bump for the signer"
-            ],
-            "type": "u8"
-          },
-          {
             "name": "passExpireTime",
             "docs": [
               "The length of time a pass lasts in seconds. `0` means does not expire."
@@ -2266,13 +2259,6 @@ export const IDL: SolanaAnchorGateway = {
               "the index of the network"
             ],
             "type": "u16"
-          },
-          {
-            "name": "networkBump",
-            "docs": [
-              "The bump for the signer"
-            ],
-            "type": "u8"
           },
           {
             "name": "passExpireTime",

--- a/solana/program_v2/programs/gateway_v2/src/state/network.rs
+++ b/solana/program_v2/programs/gateway_v2/src/state/network.rs
@@ -17,9 +17,6 @@ pub struct GatekeeperNetwork {
     pub authority: Pubkey,
     /// the index of the network
     pub network_index: u16,
-    // TODO: Remove this
-    /// The bump for the signer
-    pub network_bump: u8,
     /// The length of time a pass lasts in seconds. `0` means does not expire.
     pub pass_expire_time: i64,
     /// Features on the network, index relates to which feature it is. There are 32 bytes of data available for each feature.


### PR DESCRIPTION
Remove unused network_bump since we moved network away from PDA IDCOM-2315