### PR TITLE
IDCOM-2271 Add GitHub Actions to automate the release of NPM packages

### DIFF
--- a/.github/workflows/npm-auto-publish-workflow.yaml
+++ b/.github/workflows/npm-auto-publish-workflow.yaml
@@ -1,0 +1,63 @@
+# This Github Action is designed to automatically publish NPM packages.
+#
+# While this Github Action will often be triggered, it will only publish a new package
+# if the version specified in the package.json file(s) is behind that already published.
+#
+# Further documentation on how this webhook works can be found at the following URL:
+# https://github.com/marketplace/actions/npm-publish
+
+name: "NPM Auto Publish Workflow"
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: |
+          Choose from which environment to run this workflow
+        required: true
+        type: string
+      production-branch:
+        description: |
+          Changes pushed to this branch will always be tagged with a "latest" tag
+          Any other branch will default to receiving an "alpha" tag.
+        required: true
+        type: string
+      package-path:
+        description: |
+          Provide the path to your package.json file
+        required: true
+        type: string
+    secrets:
+      publish-token:
+        required: true
+
+jobs:
+  publish-npm:
+    environment: ${{ inputs.environment }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org/
+
+      - name: Extract Tag Value
+        id: extract-tag-value
+        shell: bash
+        run: |
+          if [ "${GITHUB_REF##*/}" == "${{ inputs.production-branch }}" ]; then
+            echo "Using 'Latest' Tag"
+            echo "tag-value=latest" >> $GITHUB_OUTPUT
+          else
+            echo "Using 'Alpha' Tag"
+            echo "tag-value=alpha" >> $GITHUB_OUTPUT
+          fi
+
+      - name: NPM Publish Package
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.publish-token }}
+          package: ${{ inputs.package-path }}
+          check-version: true
+          tag: ${{ steps.extract-tag-value.outputs.tag-value }}

--- a/.github/workflows/npm-auto-publish.yaml
+++ b/.github/workflows/npm-auto-publish.yaml
@@ -1,0 +1,39 @@
+name: "NPM Auto Publish"
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+    paths:
+      - "solana/program_v2/packages/client/cli/package.json"
+      - "solana/program_v2/packages/client/core/package.json"
+      - "solana/program_v2/packages/client/idl/package.json"
+
+jobs:
+  publish-gateway-solana-cli:
+    uses: "./.github/workflows/npm-auto-publish-workflow.yml"
+    with:
+      environment: "npm-auto-publish"
+      production-branch: 'main'
+      package-path: "solana/program_v2/packages/client/cli/package.json"
+    secrets:
+      publish-token: ${{ secrets.NPM_TOKEN }}
+
+  publish-gateway-solana-client:
+    uses: "./.github/workflows/npm-auto-publish-workflow.yml"
+    with:
+      environment: "npm-auto-publish"
+      production-branch: 'main'
+      package-path: "solana/program_v2/packages/client/core/package.json"
+    secrets:
+      publish-token: ${{ secrets.NPM_TOKEN }}
+
+  publish-gateway-solana-idl:
+    uses: "./.github/workflows/npm-auto-publish-workflow.yml"
+    with:
+      environment: "npm-auto-publish"
+      production-branch: 'main'
+      package-path: "solana/program_v2/packages/client/idl/package.json"
+    secrets:
+      publish-token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This commit introduces two new GitHub Actions that will automatically publish NPM packages whenever they are merged into the 'main' or 'develope' branches. The latter branch will always receive a 'beta' tag.

Note: These GitHub Actions will check and only publish a new version if the version specified in the package.json file(s) are behind that published in NPM.

Signed-off-by: Tighe Barris <4658684+tbarri@users.noreply.github.com>