### PR TITLE
Gateway: Provide common UpdateOperations trait to apply state changes

### DIFF
--- a/solana/program_v2/programs/gateway_v2/src/instructions/admin/update_network.rs
+++ b/solana/program_v2/programs/gateway_v2/src/instructions/admin/update_network.rs
@@ -3,9 +3,10 @@ use anchor_lang::prelude::*;
 use crate::errors::NetworkErrors;
 use crate::state::{
     AuthKey, GatekeeperNetwork, NetworkFeesPercentage, NetworkKeyFlags, SupportedToken,
+    UpdateOperations,
 };
 
-pub fn update_network(ctx: Context<UpdateNetworkAccount>, data: &UpdateNetworkData) -> Result<()> {
+pub fn update_network(ctx: Context<UpdateNetworkAccount>, data: UpdateNetworkData) -> Result<()> {
     let network = &mut ctx.accounts.network;
 
     // Only set the expire time if a new one is provided
@@ -13,10 +14,10 @@ pub fn update_network(ctx: Context<UpdateNetworkAccount>, data: &UpdateNetworkDa
         network.set_expire_time(pass_expire_time)?;
     }
 
-    network.update_auth_keys(&data.auth_keys, &ctx.accounts.authority)?;
-    network.update_fees(&data.fees)?;
+    network.apply_update(data.auth_keys, &ctx.accounts.authority)?;
+    network.apply_update(data.fees, &ctx.accounts.authority)?;
+    network.apply_update(data.supported_tokens, &ctx.accounts.authority)?;
     network.update_network_features(data.network_features)?;
-    network.update_supported_tokens(&data.supported_tokens)?;
 
     Ok(())
 }

--- a/solana/program_v2/programs/gateway_v2/src/instructions/network/update_gatekeeper.rs
+++ b/solana/program_v2/programs/gateway_v2/src/instructions/network/update_gatekeeper.rs
@@ -2,6 +2,7 @@ use anchor_lang::prelude::*;
 
 use crate::constants::GATEKEEPER_SEED;
 use crate::errors::GatekeeperErrors;
+use crate::state::UpdateOperations;
 use crate::state::{Gatekeeper, GatekeeperAuthKey, GatekeeperFees, GatekeeperKeyFlags};
 
 // Runs all the update methods on the passed-in gatekeeper
@@ -13,8 +14,8 @@ pub fn update_gatekeeper(
     let authority = &mut ctx.accounts.authority;
     let staking_account = &mut ctx.accounts.staking_account;
 
-    gatekeeper.add_and_remove_auth_keys(&data.auth_keys, authority)?;
-    gatekeeper.add_and_remove_fees(&data.token_fees)?;
+    gatekeeper.apply_update(data.auth_keys, authority)?;
+    gatekeeper.apply_update(data.token_fees, authority)?;
     gatekeeper.set_staking_account(staking_account)?;
 
     Ok(())

--- a/solana/program_v2/programs/gateway_v2/src/lib.rs
+++ b/solana/program_v2/programs/gateway_v2/src/lib.rs
@@ -31,7 +31,7 @@ pub mod solana_anchor_gateway {
         ctx: Context<UpdateNetworkAccount>,
         data: UpdateNetworkData,
     ) -> Result<()> {
-        instructions::admin::update_network(ctx, &data)
+        instructions::admin::update_network(ctx, data)
     }
 
     pub fn close_network(ctx: Context<CloseNetworkAccount>) -> Result<()> {

--- a/solana/program_v2/programs/gateway_v2/src/state/mod.rs
+++ b/solana/program_v2/programs/gateway_v2/src/state/mod.rs
@@ -1,9 +1,11 @@
 pub use gatekeeper::*;
 pub use network::*;
+pub use operations::*;
 pub use pass::*;
 pub use shared::*;
 
 pub mod gatekeeper;
 pub mod network;
+pub mod operations;
 pub mod pass;
 pub mod shared;

--- a/solana/program_v2/programs/gateway_v2/src/state/operations.rs
+++ b/solana/program_v2/programs/gateway_v2/src/state/operations.rs
@@ -1,0 +1,92 @@
+use anchor_lang::prelude::*;
+
+/// [UpdateOperands] contains and owns all the operands required to perform an update operation.
+/// Its purpose is to provide a named return type for the [UpdateOperations::operands] method.
+///
+/// The `receiving_container` will have matched `remove_keys` taken out of it, while
+/// `added_containers` will be appended. The actual implementation of the transfer
+/// can be found in [UpdateOperations::apply_update].
+pub struct UpdateOperands<'a, Container> {
+    receiving_container: &'a mut Vec<Container>,
+    remove_keys: Vec<Pubkey>,
+    added_containers: Vec<Container>,
+}
+
+impl<'a, Container> UpdateOperands<'a, Container> {
+    pub fn new(
+        receiving_container: &'a mut Vec<Container>,
+        remove_keys: Vec<Pubkey>,
+        added_containers: Vec<Container>,
+    ) -> UpdateOperands<'a, Container> {
+        UpdateOperands {
+            receiving_container,
+            remove_keys,
+            added_containers,
+        }
+    }
+}
+
+/// [UpdateOperations] provides functionality to apply state updates to the [crate::state::Gatekeeper]
+/// and [crate::state::GatekeeperNetwork] structs. A single [UpdateOperations::apply_update] method
+/// will be exposed after implementing this trait.
+///
+/// The generic types are used as follows:
+///
+/// * `Operation` - The type of the struct containing the add and remove fields. For example: [crate::UpdateGatekeeperKeys]
+/// * `Container` - The type being added during the update operation. For example: [crate::state::GatekeeperAuthKey]
+pub trait UpdateOperations<Operation, Container> {
+    fn apply_update(&mut self, operation: Operation, authority: &Signer) -> Result<()> {
+        let UpdateOperands {
+            receiving_container,
+            remove_keys,
+            added_containers,
+        } = Self::operands(self, operation);
+
+        for remove_key in &remove_keys {
+            let index = receiving_container
+                .iter()
+                .position(|x| Self::extract_key(x) == *remove_key);
+
+            if let Some(index) = index {
+                Self::pre_remove_validation(remove_key, authority)?;
+                receiving_container.remove(index);
+            } else {
+                Err(Self::missing_key_error())?;
+            }
+        }
+
+        for added_container in added_containers {
+            let index = receiving_container
+                .iter()
+                .position(|x| Self::extract_key(x) == Self::extract_key(&added_container));
+
+            if let Some(index) = index {
+                Self::pre_add_validation(&added_container, authority)?;
+                receiving_container[index] = added_container;
+            } else {
+                receiving_container.push(added_container);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Helper function to partition which members of struct implementing this trait
+    /// are to receive mutations. Documentation on the return type can be found in [UpdateOperands].
+    fn operands(this: &mut Self, operation: Operation) -> UpdateOperands<Container>;
+
+    /// Helper function to extract a [Pubkey] type from a [Container] type.
+    fn extract_key(container: &Container) -> Pubkey;
+
+    /// If a [Pubkey] that was requested to be removed is not present, an [Error]
+    /// will be returned. This function allows one ot specify the error code to be returned.
+    fn missing_key_error() -> Error;
+
+    /// Before a [Pubkey] is removed, the opportunity to perform validations is given.
+    /// Returning an [Ok] result indicates all validations passed.
+    fn pre_remove_validation(key: &Pubkey, authority: &Signer) -> Result<()>;
+
+    /// Before a [Container] is added, the opportunity to perform validations is given.
+    /// Returning an [Ok] result indicates all validations passed.
+    fn pre_add_validation(container: &Container, authority: &Signer) -> Result<()>;
+}


### PR DESCRIPTION
This change introduces a new UpdateOperations trait that can be
implemented to apply 'add' and 'remove' state changes to the Gatekeeper
and GatekeeperNetwork structs. Previous duplicated logic is removed in
favour of this trait.

Signed-off-by: Tighe Barris <4658684+tbarri@users.noreply.github.com>