### PR TITLE
Fix the resolution of the cargo crates manifiest file during auto-publish

### DIFF
--- a/.github/workflows/crates-auto-publish-workflow.yml
+++ b/.github/workflows/crates-auto-publish-workflow.yml
@@ -31,9 +31,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build
-        run: cargo build --verbose
+        run: cargo build --verbose --manifest-path ${{ inputs.package-path }}
       - name: Run tests
-        run: cargo test --verbose
+        run: cargo test --verbose --manifest-path ${{ inputs.package-path }}
 
   publish-cargo:
     needs: build


### PR DESCRIPTION
This change provides the "--manifest-path" flag to the Cargo CLI when
building packages during the Crates Auto Publish workflow. Previously,
the path would default to the current directory. This fails as we
nest different cargo packages within this repo. Explicitly providing
the path allows the build to succeed.

Signed-off-by: Tighe Barris <4658684+tbarri@users.noreply.github.com>
