### PR TITLE
Adjust pre-producation NPM packages to be tagged with a "Beta" flag

### DIFF
--- a/.github/workflows/npm-auto-publish-workflow.yml
+++ b/.github/workflows/npm-auto-publish-workflow.yml
@@ -50,8 +50,8 @@ jobs:
             echo "Using 'Latest' Tag"
             echo "tag-value=latest" >> $GITHUB_OUTPUT
           else
-            echo "Using 'Alpha' Tag"
-            echo "tag-value=alpha" >> $GITHUB_OUTPUT
+            echo "Using 'Beta' Tag"
+            echo "tag-value=beta" >> $GITHUB_OUTPUT
           fi
 
       - name: NPM Publish Package


### PR DESCRIPTION
Before this change, packages published on the development branch were
tagged with an "Alpha" flag. This is incosistent with package versions
which are named with "Beta". This change unifies everything
non-production to be tagged with "Beta"

Reviewed-by: William Brooks <william@identity.org>
Signed-off-by: Tighe Barris <4658684+tbarri@users.noreply.github.com>
