### PR TITLE
Increment package versions for CLI, Core & IDL packages to 2.0.0-beta.8

### DIFF
--- a/solana/program_v2/packages/client/cli/package.json
+++ b/solana/program_v2/packages/client/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/gateway-solana-cli",
-  "version": "2.0.0-beta.7",
+  "version": "2.0.0-beta.8",
   "description": "Gateway V2 CLI",
   "author": "Identity.com",
   "bin": {
@@ -17,7 +17,7 @@
     "/oclif.manifest.json"
   ],
   "dependencies": {
-    "@identity.com/gateway-solana-client": "^2.0.0-beta.7",
+    "@identity.com/gateway-solana-client": "^2.0.0-beta.8",
     "@project-serum/anchor": "^0.26.0",
     "@project-serum/anchor-cli": "^0.26.0",
     "@oclif/core": "^1",

--- a/solana/program_v2/packages/client/core/package.json
+++ b/solana/program_v2/packages/client/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/gateway-solana-client",
-  "version": "2.0.0-beta.7",
+  "version": "2.0.0-beta.8",
   "description": "Gateway Client on Solana",
   "license": "MIT",
   "main": "dist/index.js",
@@ -25,7 +25,7 @@
     "build": "tsc -p tsconfig.json"
   },
   "dependencies": {
-    "@identity.com/gateway-solana-idl": "^2.0.0-beta.7",
+    "@identity.com/gateway-solana-idl": "^2.0.0-beta.8",
     "@project-serum/anchor": "^0.26.0",
     "@project-serum/anchor-cli": "^0.26.0"
   },

--- a/solana/program_v2/packages/client/idl/package.json
+++ b/solana/program_v2/packages/client/idl/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@identity.com/gateway-solana-idl",
-    "version": "2.0.0-beta.7",
+    "version": "2.0.0-beta.8",
     "description": "Gateway IDL on Solana",
     "license": "MIT",
     "main": "dist/index.js",

--- a/solana/program_v2/packages/tests/package.json
+++ b/solana/program_v2/packages/tests/package.json
@@ -7,8 +7,8 @@
     "lint": "eslint src/**/*.ts"
   },
   "dependencies": {
-    "@identity.com/gateway-solana-client": "^2.0.0-beta.7",
-    "@identity.com/gateway-solana-idl": "^2.0.0-beta.7",
+    "@identity.com/gateway-solana-client": "^2.0.0-beta.8",
+    "@identity.com/gateway-solana-idl": "^2.0.0-beta.8",
     "@project-serum/anchor": "^0.26.0",
     "@solana/spl-token": "^0.3.5",
     "@solana/web3.js": "^1.41.3"


### PR DESCRIPTION
This commit increments the package versions of the CLI, Core and IDL
packages from version 2.0.0-beta.7 to 2.0.0-beta.8.

Signed-off-by: Tighe Barris <4658684+tbarri@users.noreply.github.com>
