### PR TITLE
solana/gateway_v2: Fix create_network when data is being passed in

### DIFF
--- a/solana/program_v2/packages/client/core/src/NetworkService.ts
+++ b/solana/program_v2/packages/client/core/src/NetworkService.ts
@@ -163,7 +163,6 @@ export class NetworkService extends AbstractService {
           key: this._gatekeeper,
         },
       ],
-      supportedTokens: [],
     },
     authority: PublicKey = this._wallet.publicKey
   ): ServiceBuilder {
@@ -172,7 +171,13 @@ export class NetworkService extends AbstractService {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       .createGatekeeper({
-        tokenFees: data.tokenFees,
+        tokenFees: data.tokenFees.map((fee) => ({
+          token: fee.token,
+          issue: new anchor.BN(fee.issue),
+          expire: new anchor.BN(fee.expire),
+          verify: new anchor.BN(fee.verify),
+          refresh: new anchor.BN(fee.refresh),
+        })),
         authThreshold: data.authThreshold,
         authKeys: data.authKeys,
       })
@@ -214,7 +219,7 @@ export class NetworkService extends AbstractService {
         authThreshold: data.authThreshold,
         tokenFees: {
           add: data.tokenFees.add.map((fee) => ({
-            token: fee?.token,
+            token: fee.token,
             issue: new anchor.BN(fee.issue),
             expire: new anchor.BN(fee.expire),
             verify: new anchor.BN(fee.verify),

--- a/solana/program_v2/packages/client/core/src/lib/types.ts
+++ b/solana/program_v2/packages/client/core/src/lib/types.ts
@@ -89,7 +89,6 @@ export type CreateGatekeeperData = {
   tokenFees: FeeStructure[];
   authThreshold: number;
   authKeys: AuthKeyStructure[];
-  supportedTokens: SupportedToken[];
 };
 
 export type UpdateGatekeeperData = {

--- a/solana/program_v2/packages/client/idl/src/solana_anchor_gateway.ts
+++ b/solana/program_v2/packages/client/idl/src/solana_anchor_gateway.ts
@@ -1,5 +1,5 @@
 export type SolanaAnchorGateway = {
-  "version": "2.0.2",
+  "version": "2.0.5",
   "name": "solana_anchor_gateway",
   "instructions": [
     {
@@ -1528,7 +1528,7 @@ export type SolanaAnchorGateway = {
 };
 
 export const IDL: SolanaAnchorGateway = {
-  "version": "2.0.2",
+  "version": "2.0.5",
   "name": "solana_anchor_gateway",
   "instructions": [
     {

--- a/solana/program_v2/packages/tests/src/gatekeeper-suite/create-gatekeeper.test.ts
+++ b/solana/program_v2/packages/tests/src/gatekeeper-suite/create-gatekeeper.test.ts
@@ -116,7 +116,6 @@ describe('Gateway v2 Client', () => {
               tokenFees: [],
               authThreshold: 1,
               authKeys: [],
-              supportedTokens: [],
             }
           )
           .withPartialSigners(adminAuthority)
@@ -141,7 +140,6 @@ describe('Gateway v2 Client', () => {
                 key: gatekeeperAuthority.publicKey,
               },
             ],
-            supportedTokens: [],
           }
         )
         .withPartialSigners(adminAuthority)

--- a/solana/program_v2/packages/tests/src/test-set-up.ts
+++ b/solana/program_v2/packages/tests/src/test-set-up.ts
@@ -8,6 +8,7 @@ import {
 import {
   AdminService,
   airdrop,
+  CreateGatekeeperData,
   GatekeeperService,
   NetworkKeyFlags,
   NetworkService,
@@ -20,7 +21,6 @@ import {
   mintTo,
 } from '@solana/spl-token';
 import { Account } from '@solana/spl-token/src/state/account';
-import { setGatekeeperFlagsAndFees } from './util/lib';
 import { NetworkFeatures } from '@identity.com/gateway-solana-client/dist/lib/constants';
 
 export const setUpAdminNetworkGatekeeper = async (
@@ -131,24 +131,28 @@ export const setUpAdminNetworkGatekeeper = async (
     .withPartialSigners(networkAuthority)
     .rpc();
 
+  const gatekeeperDate: CreateGatekeeperData = {
+    tokenFees: [
+      { token: mint, issue: 1000, refresh: 1000, expire: 1000, verify: 1000 },
+    ],
+    authKeys: [
+      {
+        flags: 65535,
+        key: gatekeeperAuthority.publicKey,
+      },
+    ],
+    authThreshold: 1,
+  };
+
   await networkService
     .createGatekeeper(
       networkAuthority.publicKey,
       stakingPDA,
-      adminAuthority.publicKey
+      adminAuthority.publicKey,
+      gatekeeperDate
     )
     .withPartialSigners(adminAuthority)
     .rpc();
-
-  await setGatekeeperFlagsAndFees(stakingPDA, networkService, 65535, [
-    {
-      token: mint,
-      issue: 1000,
-      refresh: 1000,
-      expire: 1000,
-      verify: 1000,
-    },
-  ]);
 
   const passAccount = await GatekeeperService.createPassAddress(
     subject.publicKey,

--- a/solana/program_v2/programs/gateway_v2/src/instructions/network/create_gatekeeper.rs
+++ b/solana/program_v2/programs/gateway_v2/src/instructions/network/create_gatekeeper.rs
@@ -53,8 +53,8 @@ pub struct CreateGatekeeperAccount<'info> {
     init,
     payer = payer,
     space = Gatekeeper::size(
-    data.auth_keys.len(),
     data.token_fees.len(),
+    data.auth_keys.len(),
     ),
     seeds = [GATEKEEPER_SEED, authority.key().as_ref(), network.key().as_ref()],
     bump

--- a/solana/program_v2/programs/gateway_v2/src/state/gatekeeper.rs
+++ b/solana/program_v2/programs/gateway_v2/src/state/gatekeeper.rs
@@ -209,7 +209,7 @@ pub enum GatekeeperState {
 }
 
 impl OnChainSize for GatekeeperState {
-    const ON_CHAIN_SIZE: usize = 1;
+    const ON_CHAIN_SIZE: usize = 1 + 2;
 }
 
 #[derive(Clone, Debug)]
@@ -248,7 +248,7 @@ pub struct GatekeeperFees {
 }
 
 impl OnChainSize for GatekeeperFees {
-    const ON_CHAIN_SIZE: usize = OC_SIZE_PUBKEY + OC_SIZE_U16 * 4;
+    const ON_CHAIN_SIZE: usize = OC_SIZE_PUBKEY + OC_SIZE_U64 * 4;
 }
 
 bitflags! {


### PR DESCRIPTION
With this PR we have a bug where when passing in a data object to the create_network call we get an error `AccountDidNotSerialize`. If you didn't pass in data the call would be successful. This led me to believe this was an error in the space calculation o the call.  This is making the CLI tool break for the gatekeeper creation.

There were two errors, one in the state calculation and the other for fees.

PR: https://github.com/identity-com/on-chain-identity-gateway/pull/396

Signed off by: 