### PR TITLE
solana/gateway_v2: Add constraint so gatekeepers can only be created …

### DIFF
--- a/solana/program_v2/packages/client/idl/src/solana_anchor_gateway.ts
+++ b/solana/program_v2/packages/client/idl/src/solana_anchor_gateway.ts
@@ -1496,36 +1496,41 @@ export type SolanaAnchorGateway = {
     },
     {
       "code": 6007,
+      "name": "InsufficientAccessCreateGatekeeper",
+      "msg": "Insufficient access to create gatekeeper"
+    },
+    {
+      "code": 6008,
       "name": "AuthKeyNotFound",
       "msg": "Auth key not found"
     },
     {
-      "code": 6008,
+      "code": 6009,
       "name": "InvalidKey",
       "msg": "Invalid key provided"
     },
     {
-      "code": 6009,
+      "code": 6010,
       "name": "AccountInUse",
       "msg": "The network account is in use"
     },
     {
-      "code": 6010,
+      "code": 6011,
       "name": "FeesNotProvided",
       "msg": "Network Fee was not provided"
     },
     {
-      "code": 6011,
+      "code": 6012,
       "name": "NetworkFeeOutOfBounds",
       "msg": "Network Fee more than 100%"
     },
     {
-      "code": 6012,
+      "code": 6013,
       "name": "TokenNotSupported",
       "msg": "Token not supported"
     },
     {
-      "code": 6013,
+      "code": 6014,
       "name": "UnsupportedNetworkFeature",
       "msg": "A network feature is not enabled for this instruction"
     }
@@ -3030,36 +3035,41 @@ export const IDL: SolanaAnchorGateway = {
     },
     {
       "code": 6007,
+      "name": "InsufficientAccessCreateGatekeeper",
+      "msg": "Insufficient access to create gatekeeper"
+    },
+    {
+      "code": 6008,
       "name": "AuthKeyNotFound",
       "msg": "Auth key not found"
     },
     {
-      "code": 6008,
+      "code": 6009,
       "name": "InvalidKey",
       "msg": "Invalid key provided"
     },
     {
-      "code": 6009,
+      "code": 6010,
       "name": "AccountInUse",
       "msg": "The network account is in use"
     },
     {
-      "code": 6010,
+      "code": 6011,
       "name": "FeesNotProvided",
       "msg": "Network Fee was not provided"
     },
     {
-      "code": 6011,
+      "code": 6012,
       "name": "NetworkFeeOutOfBounds",
       "msg": "Network Fee more than 100%"
     },
     {
-      "code": 6012,
+      "code": 6013,
       "name": "TokenNotSupported",
       "msg": "Token not supported"
     },
     {
-      "code": 6013,
+      "code": 6014,
       "name": "UnsupportedNetworkFeature",
       "msg": "A network feature is not enabled for this instruction"
     }

--- a/solana/program_v2/packages/tests/src/gatekeeper-suite/create-gatekeeper.test.ts
+++ b/solana/program_v2/packages/tests/src/gatekeeper-suite/create-gatekeeper.test.ts
@@ -73,7 +73,10 @@ describe('Gateway v2 Client', () => {
       passExpireTime: 16,
       fees: [fees],
       authKeys: [
-        { flags: NetworkKeyFlags.AUTH, key: networkAuthority.publicKey },
+        {
+          flags: NetworkKeyFlags.AUTH | NetworkKeyFlags.CREATE_GATEKEEPER,
+          key: gatekeeperAuthority.publicKey,
+        },
       ],
       supportedTokens: [],
       networkFeatures: 0,

--- a/solana/program_v2/packages/tests/src/test-set-up.ts
+++ b/solana/program_v2/packages/tests/src/test-set-up.ts
@@ -101,7 +101,10 @@ export const setUpAdminNetworkGatekeeper = async (
         },
       ],
       authKeys: [
-        { flags: NetworkKeyFlags.AUTH, key: gatekeeperAuthority.publicKey },
+        {
+          flags: NetworkKeyFlags.AUTH | NetworkKeyFlags.CREATE_GATEKEEPER,
+          key: gatekeeperAuthority.publicKey,
+        },
       ],
       supportedTokens: [{ key: mint }],
       networkFeatures: NetworkFeatures.CHANGE_PASS_GATEKEEPER,

--- a/solana/program_v2/programs/gateway_v2/src/errors.rs
+++ b/solana/program_v2/programs/gateway_v2/src/errors.rs
@@ -16,6 +16,8 @@ pub enum NetworkErrors {
     InsufficientAccessTokens,
     #[msg("Insufficient access to set fees")]
     InsufficientAccessFees,
+    #[msg("Insufficient access to create gatekeeper")]
+    InsufficientAccessCreateGatekeeper,
     #[msg("Auth key not found")]
     AuthKeyNotFound,
     #[msg("Invalid key provided")]

--- a/solana/program_v2/programs/gateway_v2/src/instructions/network/create_gatekeeper.rs
+++ b/solana/program_v2/programs/gateway_v2/src/instructions/network/create_gatekeeper.rs
@@ -1,13 +1,11 @@
 use anchor_lang::prelude::*;
 
 use crate::constants::GATEKEEPER_SEED;
-use crate::errors::GatekeeperErrors;
+use crate::errors::{GatekeeperErrors, NetworkErrors};
 use crate::state::gatekeeper::{Gatekeeper, GatekeeperFees, GatekeeperState};
-use crate::state::{GatekeeperAuthKey, GatekeeperNetwork};
+use crate::state::{GatekeeperAuthKey, GatekeeperNetwork, NetworkKeyFlags};
 use crate::util::check_gatekeeper_auth_threshold;
 
-// TODO: Right now ANYONE can create a Gatekeeper in a Network. This should be restricted to an authority
-// in network.auth_keys.
 pub fn create_gatekeeper(
     ctx: Context<CreateGatekeeperAccount>,
     data: CreateGatekeeperData,
@@ -73,6 +71,7 @@ pub struct CreateGatekeeperAccount<'info> {
     ),
     realloc::payer = payer,
     realloc::zero = false,
+    constraint = network.can_access(&authority, NetworkKeyFlags::CREATE_GATEKEEPER) @ NetworkErrors::InsufficientAccessCreateGatekeeper,
     )]
     pub network: Account<'info, GatekeeperNetwork>,
     #[account(mut)]


### PR DESCRIPTION
This change applies a constraint so that the network has a CREATE_GATEKEEPER key when creating a gatekeeper. 