### PR TITLE
L07 audit - locking of initializer functions

### DIFF
--- a/ethereum/smart-contract/contracts/FlagsStorage.sol
+++ b/ethereum/smart-contract/contracts/FlagsStorage.sol
@@ -54,7 +54,9 @@ contract FlagsStorage is Initializable, IFlagsStorage, UUPSUpgradeable {
     /// @custom:oz-upgrades-unsafe-allow constructor
     // empty constructor in line with the UUPS upgradeable proxy pattern
     // solhint-disable-next-line no-empty-blocks
-    constructor() initializer {}
+    constructor() {
+        _disableInitializers();
+    }
 
     function initialize(address _superAdmin) external initializer {
         if (_superAdmin == address(0)) revert Common__MissingAccount();

--- a/ethereum/smart-contract/contracts/GatewayToken.sol
+++ b/ethereum/smart-contract/contracts/GatewayToken.sol
@@ -62,11 +62,12 @@ contract GatewayToken is
     mapping(uint => string) internal _networks;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    // constructor is empty as we are using the proxy pattern,
+    // constructor is "empty" as we are using the proxy pattern,
     // where setup code is in the initialize function
     // called by the proxy contract
-    // solhint-disable-next-line no-empty-blocks
-    constructor() initializer {}
+    constructor() {
+        _disableInitializers();
+    }
 
     function initialize(
         string memory _name,

--- a/ethereum/smart-contract/contracts/MultiERC2771Context.sol
+++ b/ethereum/smart-contract/contracts/MultiERC2771Context.sol
@@ -9,9 +9,9 @@ import {ContextUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/Cont
 abstract contract MultiERC2771Context is ContextUpgradeable {
     mapping(address => bool) private _trustedForwarders;
 
-    /// @custom:oz-upgrades-unsafe-allow constructor
-    // solhint-disable-next-line no-empty-blocks
-    constructor() initializer {}
+    // because MultiERC2771Context is abstract we don't implement a
+    // constructor. It's the responsibility of the derived contract to
+    // disable the Initializers with "_disableInitializers()"
 
     // solhint-disable-next-line func-name-mixedcase
     function __MultiERC2771Context_init(address[] memory trustedForwarders) internal initializer {


### PR DESCRIPTION
fix: Implemented correct locking of initializer functions in the constructor of the implementation contracts.