### PR TITLE
Update civicnet URL so CLI -c civicnet will work again

### DIFF
--- a/protocol/token-usage-settlement/program/src/lib/util.ts
+++ b/protocol/token-usage-settlement/program/src/lib/util.ts
@@ -18,7 +18,7 @@ const DEFAULT_COMMITMENT: Commitment = "confirmed";
 
 export type ExtendedCluster = Cluster | "localnet" | "civicnet";
 export const CIVICNET_URL =
-  "http://ec2-34-238-243-215.compute-1.amazonaws.com:8899";
+  "http://ec2-44-214-135-83.compute-1.amazonaws.com:8899";
 
 export const getClusterUrl = (cluster: ExtendedCluster): string => {
   switch (cluster) {

--- a/protocol/token-usage-settlement/solana-ociv-usage/src/util/connection.ts
+++ b/protocol/token-usage-settlement/solana-ociv-usage/src/util/connection.ts
@@ -11,7 +11,7 @@ import { SOLANA_COMMITMENT } from "./constants";
 
 export type ExtendedCluster = Cluster | "localnet" | "civicnet";
 export const CIVICNET_URL =
-  "http://ec2-34-238-243-215.compute-1.amazonaws.com:8899";
+  "http://ec2-44-214-135-83.compute-1.amazonaws.com:8899";
 
 export const getClusterUrl = (cluster: ExtendedCluster) => {
   switch (cluster) {

--- a/solana/gatekeeper-cli/src/util/utils.ts
+++ b/solana/gatekeeper-cli/src/util/utils.ts
@@ -5,7 +5,7 @@ import { GatewayToken } from "@identity.com/solana-gateway-ts";
 export type ExtendedCluster = Cluster | "localnet" | "civicnet";
 
 export const CIVICNET_URL =
-    "http://ec2-34-238-243-215.compute-1.amazonaws.com:8899";
+    "http://ec2-44-214-135-83.compute-1.amazonaws.com:8899";
 
 export const getTokenUpdateProperties = async (
   args: { [p: string]: any },

--- a/solana/gatekeeper-lib/scripts/mintAuth.yml
+++ b/solana/gatekeeper-lib/scripts/mintAuth.yml
@@ -1,5 +1,5 @@
 ---
-json_rpc_url: "http://ec2-34-238-243-215.compute-1.amazonaws.com:8899"
+json_rpc_url: "http://ec2-44-214-135-83.compute-1.amazonaws.com:8899"
 websocket_url: ""
 # Include the private key for the mint authority in this file to use the mint script
 keypair_path: ../keys/mintid.json

--- a/solana/gatekeeper-lib/src/util/connection.ts
+++ b/solana/gatekeeper-lib/src/util/connection.ts
@@ -16,7 +16,7 @@ import { SOLANA_COMMITMENT } from "./constants";
 
 export type ExtendedCluster = Cluster | "localnet" | "civicnet";
 export const CIVICNET_URL =
-  "http://ec2-34-238-243-215.compute-1.amazonaws.com:8899";
+  "http://ec2-44-214-135-83.compute-1.amazonaws.com:8899";
 
 export const getClusterUrl = (cluster: ExtendedCluster): string => {
   switch (cluster) {

--- a/solana/gateway-ts/scripts/getGatekeeperAccount.ts
+++ b/solana/gateway-ts/scripts/getGatekeeperAccount.ts
@@ -4,7 +4,7 @@ import { gatekeeperExists } from "../src";
 // default to the civic cluster
 const endpoint =
   process.env.CLUSTER_ENDPOINT ||
-  "http://ec2-34-238-243-215.compute-1.amazonaws.com:8899";
+  "http://ec2-44-214-135-83.compute-1.amazonaws.com:8899";
 
 const connection = new Connection(endpoint, "processed");
 


### PR DESCRIPTION
The civicnet EC2 box was recreated so the URL has changed.
This update is needed for the gateway CLI to work with civicnet again.