### PR TITLE
Solana: Add CLI flags for priorityFee and skipPreflight

### DIFF
--- a/solana/gatekeeper-cli/README.md
+++ b/solana/gatekeeper-cli/README.md
@@ -19,7 +19,7 @@ $ npm install -g @identity.com/solana-gatekeeper-cli
 $ gateway COMMAND
 running command...
 $ gateway (-v|--version|version)
-@identity.com/solana-gatekeeper-cli/0.0.2 darwin-arm64 node-v18.16.0
+@identity.com/solana-gatekeeper-cli/0.0.2 darwin-x64 node-v20.12.0
 $ gateway --help [COMMAND]
 USAGE
   $ gateway COMMAND
@@ -66,6 +66,8 @@ OPTIONS
                                                                SOLANA_CLUSTER. To override this property with a specific
                                                                endpoint url, set SOLANA_CLUSTER_URL
 
+  -f, --priorityFeeLamports=priorityFeeLamports                [default: 0] The priority fee in lamports
+
   -g, --gatekeeperKey=gatekeeperKey                            [default: [object Object]] The private key file for the
                                                                gatekeeper authority
 
@@ -73,6 +75,8 @@ OPTIONS
 
   -n, --gatekeeperNetworkKey=gatekeeperNetworkKey              [default: [object Object]] The private key file for the
                                                                gatekeeper authority
+
+  --skipPreflight                                              Skip preflight check
 
 EXAMPLE
   $ gateway add-gatekeeper tgky5YfBseCvqehzsycwCG6rh2udA4w14MxZMnZz9Hp
@@ -97,6 +101,8 @@ OPTIONS
                                                                SOLANA_CLUSTER. To override this property with a specific
                                                                endpoint url, set SOLANA_CLUSTER_URL
 
+  -f, --priorityFeeLamports=priorityFeeLamports                [default: 0] The priority fee in lamports
+
   -g, --gatekeeperKey=gatekeeperKey                            [default: [object Object]] The private key file for the
                                                                gatekeeper authority
 
@@ -105,9 +111,11 @@ OPTIONS
   -n, --gatekeeperNetworkKey=gatekeeperNetworkKey              [default: [object Object]] The public key (in base 58) of
                                                                the gatekeeper network that the gatekeeper belongs to.
 
+  --skipPreflight                                              Skip preflight check
+
 EXAMPLE
   $ gateway burn EzZgkwaDrgycsiyGeCVRXXRcieE1fxhGMp829qwj5TMv
-  Revoked
+  Burned
 ```
 
 ## `gateway freeze GATEWAYTOKEN`
@@ -129,6 +137,8 @@ OPTIONS
                                                                SOLANA_CLUSTER. To override this property with a specific
                                                                endpoint url, set SOLANA_CLUSTER_URL
 
+  -f, --priorityFeeLamports=priorityFeeLamports                [default: 0] The priority fee in lamports
+
   -g, --gatekeeperKey=gatekeeperKey                            [default: [object Object]] The private key file for the
                                                                gatekeeper authority
 
@@ -136,6 +146,8 @@ OPTIONS
 
   -n, --gatekeeperNetworkKey=gatekeeperNetworkKey              [default: [object Object]] The public key (in base 58) of
                                                                the gatekeeper network that the gatekeeper belongs to.
+
+  --skipPreflight                                              Skip preflight check
 
 EXAMPLE
   $ gateway freeze EzZgkwaDrgycsiyGeCVRXXRcieE1fxhGMp829qwj5TMv
@@ -181,6 +193,8 @@ OPTIONS
   -e, --expiry=expiry                                          The expiry time in seconds for the gateway token (default
                                                                none)
 
+  -f, --priorityFeeLamports=priorityFeeLamports                [default: 0] The priority fee in lamports
+
   -g, --gatekeeperKey=gatekeeperKey                            [default: [object Object]] The private key file for the
                                                                gatekeeper authority
 
@@ -188,6 +202,8 @@ OPTIONS
 
   -n, --gatekeeperNetworkKey=gatekeeperNetworkKey              [default: [object Object]] The public key (in base 58) of
                                                                the gatekeeper network that the gatekeeper belongs to.
+
+  --skipPreflight                                              Skip preflight check
 
 EXAMPLE
   $ gateway issue EzZgkwaDrgycsiyGeCVRXXRcieE1fxhGMp829qwj5TMv2QJjjrzdPSrcZUuAH2KrEU61crWz49KnSLSzwjDUnLSV
@@ -212,12 +228,16 @@ OPTIONS
                                                                SOLANA_CLUSTER. To override this property with a specific
                                                                endpoint url, set SOLANA_CLUSTER_URL
 
+  -f, --priorityFeeLamports=priorityFeeLamports                [default: 0] The priority fee in lamports
+
   -h, --help                                                   Show CLI help.
 
   -n, --gatekeeperNetworkKey=gatekeeperNetworkKey              [default: [object Object]] The private key file for the
                                                                gatekeeper authority
 
   -o, --featureOperation=add|remove|get                        [default: get] add, remove, or get a network feature
+
+  --skipPreflight                                              Skip preflight check
 
 EXAMPLE
   $ gateway network-feature userTokenExpiry
@@ -381,6 +401,8 @@ OPTIONS
                                                                SOLANA_CLUSTER. To override this property with a specific
                                                                endpoint url, set SOLANA_CLUSTER_URL
 
+  -f, --priorityFeeLamports=priorityFeeLamports                [default: 0] The priority fee in lamports
+
   -g, --gatekeeperKey=gatekeeperKey                            [default: [object Object]] The private key file for the
                                                                gatekeeper authority
 
@@ -388,6 +410,8 @@ OPTIONS
 
   -n, --gatekeeperNetworkKey=gatekeeperNetworkKey              [default: [object Object]] The public key (in base 58) of
                                                                the gatekeeper network that the gatekeeper belongs to.
+
+  --skipPreflight                                              Skip preflight check
 
 EXAMPLE
   $ gateway refresh EzZgkwaDrgycsiyGeCVRXXRcieE1fxhGMp829qwj5TMv 54000
@@ -413,6 +437,8 @@ OPTIONS
                                                                SOLANA_CLUSTER. To override this property with a specific
                                                                endpoint url, set SOLANA_CLUSTER_URL
 
+  -f, --priorityFeeLamports=priorityFeeLamports                [default: 0] The priority fee in lamports
+
   -g, --gatekeeperKey=gatekeeperKey                            [default: [object Object]] The private key file for the
                                                                gatekeeper authority
 
@@ -420,6 +446,8 @@ OPTIONS
 
   -n, --gatekeeperNetworkKey=gatekeeperNetworkKey              [default: [object Object]] The public key (in base 58) of
                                                                the gatekeeper network that the gatekeeper belongs to.
+
+  --skipPreflight                                              Skip preflight check
 
 EXAMPLE
   $ gateway revoke EzZgkwaDrgycsiyGeCVRXXRcieE1fxhGMp829qwj5TMv
@@ -445,6 +473,8 @@ OPTIONS
                                                                SOLANA_CLUSTER. To override this property with a specific
                                                                endpoint url, set SOLANA_CLUSTER_URL
 
+  -f, --priorityFeeLamports=priorityFeeLamports                [default: 0] The priority fee in lamports
+
   -g, --gatekeeperKey=gatekeeperKey                            [default: [object Object]] The private key file for the
                                                                gatekeeper authority
 
@@ -452,6 +482,8 @@ OPTIONS
 
   -n, --gatekeeperNetworkKey=gatekeeperNetworkKey              [default: [object Object]] The private key file for the
                                                                gatekeeper authority
+
+  --skipPreflight                                              Skip preflight check
 
 EXAMPLE
   $ gateway revoke-gatekeeper tgky5YfBseCvqehzsycwCG6rh2udA4w14MxZMnZz9Hp
@@ -476,6 +508,8 @@ OPTIONS
                                                                SOLANA_CLUSTER. To override this property with a specific
                                                                endpoint url, set SOLANA_CLUSTER_URL
 
+  -f, --priorityFeeLamports=priorityFeeLamports                [default: 0] The priority fee in lamports
+
   -g, --gatekeeperKey=gatekeeperKey                            [default: [object Object]] The private key file for the
                                                                gatekeeper authority
 
@@ -483,6 +517,8 @@ OPTIONS
 
   -n, --gatekeeperNetworkKey=gatekeeperNetworkKey              [default: [object Object]] The public key (in base 58) of
                                                                the gatekeeper network that the gatekeeper belongs to.
+
+  --skipPreflight                                              Skip preflight check
 
 EXAMPLE
   $ gateway unfreeze EzZgkwaDrgycsiyGeCVRXXRcieE1fxhGMp829qwj5TMv

--- a/solana/gatekeeper-cli/src/commands/add-gatekeeper.ts
+++ b/solana/gatekeeper-cli/src/commands/add-gatekeeper.ts
@@ -7,6 +7,8 @@ import {
   clusterFlag,
   gatekeeperKeyFlag,
   gatekeeperNetworkKeyFlag,
+  prioFeeFlag,
+  skipPreflightFlag,
 } from "../util/flags";
 import { getConnectionFromEnv } from "../util/utils";
 
@@ -24,6 +26,8 @@ export default class AddGatekeeper extends Command {
     gatekeeperNetworkKey: gatekeeperNetworkKeyFlag(),
     cluster: clusterFlag(),
     airdrop: airdropFlag,
+    priorityFeeLamports: prioFeeFlag(),
+    skipPreflight: skipPreflightFlag,
   };
 
   static args = [
@@ -60,8 +64,8 @@ export default class AddGatekeeper extends Command {
       gatekeeperNetwork
     );
     const gatekeeperAccount = await networkService
-      .addGatekeeper(gatekeeper)
-      .then((t) => t.send())
+      .addGatekeeper(gatekeeper, flags.priorityFeeLamports ? { priorityFeeMicroLamports: flags.priorityFeeLamports } : undefined)
+      .then((t) => t.send(flags.skipPreflight ? {skipPreflight: true}: {}))
       .then((t) => t.confirm());
     this.log(
       `Added gatekeeper to network. Gatekeeper account: ${

--- a/solana/gatekeeper-cli/src/commands/burn.ts
+++ b/solana/gatekeeper-cli/src/commands/burn.ts
@@ -5,6 +5,8 @@ import {
   clusterFlag,
   gatekeeperKeyFlag,
   gatekeeperNetworkPubkeyFlag,
+  prioFeeFlag,
+  skipPreflightFlag,
 } from "../util/flags";
 import { getTokenUpdateProperties } from "../util/utils";
 
@@ -23,6 +25,8 @@ Burned
     gatekeeperNetworkKey: gatekeeperNetworkPubkeyFlag(),
     cluster: clusterFlag(),
     airdrop: airdropFlag,
+    priorityFeeLamports: prioFeeFlag(),
+    skipPreflight: skipPreflightFlag,
   };
 
   static args = [
@@ -47,7 +51,7 @@ Burned
 
     await service
       .burn(gatewayToken)
-      .then((t) => t.send())
+      .then((t) => t.send(flags.skipPreflight ? {skipPreflight: true}: {}))
       .then((t) => t.confirm());
 
     this.log("Burned");

--- a/solana/gatekeeper-cli/src/commands/freeze.ts
+++ b/solana/gatekeeper-cli/src/commands/freeze.ts
@@ -5,6 +5,8 @@ import {
   clusterFlag,
   gatekeeperKeyFlag,
   gatekeeperNetworkPubkeyFlag,
+  prioFeeFlag,
+  skipPreflightFlag,
 } from "../util/flags";
 import { getTokenUpdateProperties } from "../util/utils";
 
@@ -23,6 +25,8 @@ Frozen
     gatekeeperNetworkKey: gatekeeperNetworkPubkeyFlag(),
     cluster: clusterFlag(),
     airdrop: airdropFlag,
+    priorityFeeLamports: prioFeeFlag(),
+    skipPreflight: skipPreflightFlag,
   };
 
   static args = [
@@ -47,7 +51,7 @@ Frozen
 
     const frozenToken = await service
       .freeze(gatewayToken)
-      .then((t) => t.send())
+      .then((t) => t.send(flags.skipPreflight ? {skipPreflight: true}: {}))
       .then((t) => t.confirm());
 
     this.log("Frozen token", frozenToken?.publicKey.toBase58());

--- a/solana/gatekeeper-cli/src/commands/network-feature.ts
+++ b/solana/gatekeeper-cli/src/commands/network-feature.ts
@@ -2,7 +2,7 @@ import { Command, Flags } from "@oclif/core";
 import { Keypair } from "@solana/web3.js";
 
 import { airdropTo, GatekeeperNetworkService } from "@identity.com/solana-gatekeeper-lib";
-import {airdropFlag, clusterFlag, gatekeeperNetworkKeyFlag} from "../util/flags";
+import {airdropFlag, clusterFlag, gatekeeperNetworkKeyFlag, prioFeeFlag, skipPreflightFlag} from "../util/flags";
 import {
   NetworkFeature,
   UserTokenExpiry,
@@ -39,6 +39,8 @@ export default class AddNetworkFeature extends Command {
     gatekeeperNetworkKey: gatekeeperNetworkKeyFlag(),
     cluster: clusterFlag(),
     airdrop: airdropFlag,
+    priorityFeeLamports: prioFeeFlag(),
+    skipPreflight: skipPreflightFlag,
   };
 
   static args = [
@@ -108,14 +110,14 @@ export default class AddNetworkFeature extends Command {
 
     if (featureOperation === "add" && !hasNetworkFeature) {
       await networkService
-        .addNetworkFeature("find", networkFeature)
-        .then((t) => t.send())
+        .addNetworkFeature("find", networkFeature, flags.priorityFeeLamports ? { priorityFeeMicroLamports: flags.priorityFeeLamports } : undefined)
+        .then((t) => t.send(flags.skipPreflight ? {skipPreflight: true}: {}))
         .then((t) => t.confirm());
     } else if (featureOperation === "remove" && hasNetworkFeature) {
       // remove case
       await networkService
-        .removeNetworkFeature("find", networkFeature)
-        .then((t) => t.send())
+        .removeNetworkFeature("find", networkFeature, flags.priorityFeeLamports ? { priorityFeeMicroLamports: flags.priorityFeeLamports } : undefined)
+        .then((t) => t.send(flags.skipPreflight ? {skipPreflight: true}: {}))
         .then((t) => t.confirm());
     } else {
       this.log(

--- a/solana/gatekeeper-cli/src/commands/refresh.ts
+++ b/solana/gatekeeper-cli/src/commands/refresh.ts
@@ -5,6 +5,8 @@ import {
   clusterFlag,
   gatekeeperKeyFlag,
   gatekeeperNetworkPubkeyFlag,
+  prioFeeFlag,
+  skipPreflightFlag,
 } from "../util/flags";
 import { getTokenUpdateProperties } from "../util/utils";
 
@@ -23,6 +25,8 @@ Refreshed
     gatekeeperNetworkKey: gatekeeperNetworkPubkeyFlag(),
     cluster: clusterFlag(),
     airdrop: airdropFlag,
+    priorityFeeLamports: prioFeeFlag(),
+    skipPreflight: skipPreflightFlag,
   };
 
   static args = [
@@ -60,7 +64,7 @@ Refreshed
         gatewayToken,
         expiry + Math.floor(Date.now() / 1000)
       )
-      .then((t) => t.send())
+      .then((t) => t.send(flags.skipPreflight ? {skipPreflight: true}: {}))
       .then((t) => t.confirm());
 
     this.log("Refreshed");

--- a/solana/gatekeeper-cli/src/commands/revoke-gatekeeper.ts
+++ b/solana/gatekeeper-cli/src/commands/revoke-gatekeeper.ts
@@ -4,6 +4,8 @@ import {
   clusterFlag,
   gatekeeperKeyFlag,
   gatekeeperNetworkKeyFlag,
+  prioFeeFlag,
+  skipPreflightFlag,
 } from "../util/flags";
 import { Keypair, PublicKey } from "@solana/web3.js";
 import { airdropTo, GatekeeperNetworkService } from "@identity.com/solana-gatekeeper-lib";
@@ -23,6 +25,8 @@ export default class RevokeGatekeeper extends Command {
     gatekeeperNetworkKey: gatekeeperNetworkKeyFlag(),
     cluster: clusterFlag(),
     airdrop: airdropFlag,
+    priorityFeeLamports: prioFeeFlag(),
+    skipPreflight: skipPreflightFlag,
   };
 
   static args = [
@@ -59,8 +63,8 @@ export default class RevokeGatekeeper extends Command {
         gatekeeperNetwork
     );
     const gatekeeperAccount = await networkService
-        .revokeGatekeeper(gatekeeper)
-        .then((t) => t.send())
+        .revokeGatekeeper(gatekeeper, flags.priorityFeeLamports ? { priorityFeeMicroLamports: flags.priorityFeeLamports } : undefined)
+        .then((t) => t.send(flags.skipPreflight ? {skipPreflight: true}: {}))
         .then((t) => t.confirm());
     this.log(
         `Revoked gatekeeper from network. Gatekeeper account: ${

--- a/solana/gatekeeper-cli/src/commands/revoke.ts
+++ b/solana/gatekeeper-cli/src/commands/revoke.ts
@@ -5,6 +5,8 @@ import {
   clusterFlag,
   gatekeeperKeyFlag,
   gatekeeperNetworkPubkeyFlag,
+  prioFeeFlag,
+  skipPreflightFlag,
 } from "../util/flags";
 import { getTokenUpdateProperties } from "../util/utils";
 
@@ -23,6 +25,8 @@ Revoked
     gatekeeperNetworkKey: gatekeeperNetworkPubkeyFlag(),
     cluster: clusterFlag(),
     airdrop: airdropFlag,
+    priorityFeeLamports: prioFeeFlag(),
+    skipPreflight: skipPreflightFlag,
   };
 
   static args = [
@@ -47,7 +51,7 @@ Revoked
 
     await service
       .revoke(gatewayToken)
-      .then((t) => t.send())
+      .then((t) => t.send(flags.skipPreflight ? {skipPreflight: true}: {}))
       .then((t) => t.confirm());
 
     this.log("Revoked");

--- a/solana/gatekeeper-cli/src/commands/unfreeze.ts
+++ b/solana/gatekeeper-cli/src/commands/unfreeze.ts
@@ -5,6 +5,8 @@ import {
   clusterFlag,
   gatekeeperKeyFlag,
   gatekeeperNetworkPubkeyFlag,
+  prioFeeFlag,
+  skipPreflightFlag,
 } from "../util/flags";
 import { getTokenUpdateProperties } from "../util/utils";
 
@@ -23,6 +25,8 @@ Unfrozen
     gatekeeperNetworkKey: gatekeeperNetworkPubkeyFlag(),
     cluster: clusterFlag(),
     airdrop: airdropFlag,
+    priorityFeeLamports: prioFeeFlag(),
+    skipPreflight: skipPreflightFlag,
   };
 
   static args = [
@@ -47,7 +51,7 @@ Unfrozen
 
     await service
       .unfreeze(gatewayToken)
-      .then((t) => t.send())
+      .then((t) => t.send(flags.skipPreflight ? {skipPreflight: true}: {}))
       .then((t) => t.confirm());
 
     this.log("Unfrozen");

--- a/solana/gatekeeper-cli/src/util/flags.ts
+++ b/solana/gatekeeper-cli/src/util/flags.ts
@@ -10,6 +10,21 @@ const readKey = async (file: string): Promise<Keypair> => Keypair.fromSecretKey(
     new Uint8Array(JSON.parse(fs.readFileSync(file).toString("utf-8")) as number[])
 );
 
+export const prioFeeFlag = Flags.build<number>({
+  char: "f",
+  // eslint-disable-next-line @typescript-eslint/require-await
+  parse: async (prioFee: string) => Number.parseInt(prioFee, 10),
+  default: 0,
+  description:
+    "The priority fee in lamports",
+});
+
+export const skipPreflightFlag = Flags.boolean({
+  default: false,
+  description:
+    "Skip preflight check",
+});
+
 export const gatekeeperKeyFlag = Flags.build<Keypair>({
   char: "g",
   parse: readKey,

--- a/solana/gatekeeper-cli/src/util/utils.ts
+++ b/solana/gatekeeper-cli/src/util/utils.ts
@@ -10,6 +10,7 @@ export const CIVICNET_URL =
 export const getTokenUpdateProperties = async (
   args: { [p: string]: any },
   flags: {
+    priorityFeeLamports?: number | undefined;
     gatekeeperNetworkKey: PublicKey | undefined;
     help: void;
     cluster: ExtendedCluster | undefined;
@@ -30,10 +31,14 @@ export const getTokenUpdateProperties = async (
     await airdropTo(connection, gatekeeper.publicKey, flags.cluster as string);
   }
 
+  const options = {
+    ...(flags.priorityFeeLamports ? {priorityFeeMicroLamports: flags.priorityFeeLamports} : {}),
+  };
   const service = new GatekeeperService(
     connection,
     gatekeeperNetwork,
-    gatekeeper
+    gatekeeper,
+    options,
   );
   return { gatewayToken, gatekeeper, service };
 };


### PR DESCRIPTION
Solana: Add CLI flags for priorityFee and skipPreflight.
All commands that send transactions now support:
```
-f <priority fee in microlamports per CU> --skipPreflight
```
